### PR TITLE
Extract a common RequestApi

### DIFF
--- a/src/request/RequestApi.js
+++ b/src/request/RequestApi.js
@@ -1,0 +1,51 @@
+class RequestApi {
+
+    constructor() {
+        /** @type {Function} */
+        this._resolve;
+
+        /** @type {Function} */
+        this._reject;
+    }
+
+    /**
+     * Method to be called by the Keyguard client via RPC
+     *
+     * @param {object} request
+     */
+    async request(request) {
+        return new Promise((resolve, reject) => {
+            this._resolve = resolve;
+            this._reject = reject;
+
+            this.onRequest(request);
+        });
+    }
+
+    /**
+     * Overloaded by each pages' API class
+     *
+     * @param {any} request
+     */
+    onRequest(request) {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Called by a page's API class on success
+     *
+     * @param {any} result
+     */
+    resolve(result) {
+        this._resolve(result);
+    }
+
+    /**
+     * Called by a page's API class on error
+     *
+     * @param {Error} error
+     */
+    reject(error) {
+        this._reject(error);
+    }
+}

--- a/src/request/RequestApi.js
+++ b/src/request/RequestApi.js
@@ -1,3 +1,28 @@
+/**
+ * # RequestApi
+ * A common parent class for pop-up requests.
+ *
+ * ## Usage:
+ * Inherit this class in your requests API class:
+ * ```
+ *  class SignTransactionApi extends RequestApi {
+ *
+ *      // Define the onRequest method to receive the client's request object:
+ *      onRequest(request) {
+ *          // do something...
+ *
+ *          // When done, call this.resolve() with the result object
+ *          this.resolve(result);
+ *
+ *          // Or this.reject() with an error
+ *          this.reject(error);
+ *      }
+ *  }
+ *
+ *  // Finally, start your API:
+ *  runKeyguard(SignTransactionApi);
+ * ```
+ */
 class RequestApi {
 
     constructor() {

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -23,8 +23,8 @@ class SignTransactionApi extends RequestApi {
             ? new SignTransactionWithPassphrase(txRequest)
             : new SignTransactionWithPin(txRequest);
 
-        handler.on('result', /** @param {any} result */ (result) => this.resolve(result));
-        handler.on('error', /** @param {Error} error */ (error) => this.reject(error));
+        handler.on('result', /** @param {any} result */ result => this.resolve(result));
+        handler.on('error', /** @param {Error} error */ error => this.reject(error));
     }
 }
 

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -14,6 +14,7 @@
     <script src="../../lib/Utf8Tools.js"></script>
     <script src="../../common.js"></script>
     <script src="../../components/PinInput.js"></script>
+    <script src="../RequestApi.js"></script>
     <script src="SignTransactionApi.js"></script>
     <script src="SignTransactionView.js"></script>
     <script src="SignTransactionViewWithPassphrase.js"></script>


### PR DESCRIPTION
Introduces a common `PageApi` class, from which page API classes should inherit. This allows common operations to be DRY and allows to hook into the `resolve` event to write the cookie on iOS/Safari.