### PR TITLE
Add options to runKeyguard, add RPC whitelist

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -15,7 +15,9 @@ async function runKeyguard(RequestApiClass, options) {
     self.KeyStore = KeyStore;
 
     if (options.loadNimiq) {
+        // Load web assembly encryption library into browser (if supported)
         await Nimiq.WasmHelper.doImportBrowser();
+        // Configure to use test net for now
         Nimiq.GenesisConfig.test();
     }
 
@@ -26,5 +28,6 @@ async function runKeyguard(RequestApiClass, options) {
         }
     });
 
-    self.rpcServer = RpcServer.create(RequestApiClass, '*', options.rpcWhitelist); // FIXME Set correct allowedOrigin
+    // FIXME Set correct allowedOrigin
+    self.rpcServer = RpcServer.create(RequestApiClass, '*', options.rpcWhitelist); 
 }

--- a/src/common.js
+++ b/src/common.js
@@ -1,11 +1,23 @@
-/** @param {Function} RequestApiClass - Class object of the API which is to be exposed via postMessage RPC */
-async function runKeyguard(RequestApiClass) {
+/**
+ * @param {Function} RequestApiClass - Class object of the API which is to be exposed via postMessage RPC
+ * @param {object} [options]
+ */
+async function runKeyguard(RequestApiClass, options) {
+
+    const defaultOptions = {
+        loadNimiq: true,
+        rpcWhitelist: ['request'],
+    };
+
+    options = Object.assign(defaultOptions, options);
 
     // Expose KeyStore to mockup overwrites
     self.KeyStore = KeyStore;
 
-    await Nimiq.WasmHelper.doImportBrowser();
-    Nimiq.GenesisConfig.test();
+    if (options.loadNimiq) {
+        await Nimiq.WasmHelper.doImportBrowser();
+        Nimiq.GenesisConfig.test();
+    }
 
     // Close window if user navigates back to loading screen
     self.addEventListener('hashchange', () => {
@@ -14,5 +26,5 @@ async function runKeyguard(RequestApiClass) {
         }
     });
 
-    self.rpcServer = RpcServer.create(RequestApiClass, '*'); // FIXME Set correct allowedOrigin
+    self.rpcServer = RpcServer.create(RequestApiClass, '*', options.rpcWhitelist); // FIXME Set correct allowedOrigin
 }


### PR DESCRIPTION
This PR adds an _optional_ (no pun indended) `options` parameter to the common `runKeyguard()` function. It has sensible defaults, so that regular request APIs do not need to set any options, but e.g. the IFrame request API can prevent loading the Nimiq lib and whitelist other methods.