### PR TITLE
Configure ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,9 +3,31 @@
       "browser": true
   },
   "extends": "airbnb-base",
+  "globals": {
+    "AccountStore": false,
+    "AddressUtils": false,
+    "BrowserDetection": false,
+    "CookieJar": false,
+    "EncryptionType": false,
+    "I18n": false,
+    "Identicon": false,
+    "InvalidAddressError": false,
+    "Iqons": false,
+    "Key": false,
+    "KeyStore": false,
+    "LanguagePicker": false,
+    "Nimiq": false,
+    "RpcServer": false,
+    "TransactionType": false,
+    "Utf8Tools": false
+  },
   "rules": {
     "arrow-parens": ["error", "as-needed"],
+    "class-methods-use-this": ["off"],
     "indent": ["error", 4],
+    "max-len": ["error", 120],
+    "no-param-reassign": ["off"],
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-underscore-dangle": ["off"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,37 +4,42 @@
   },
   "extends": "airbnb-base",
   "globals": {
+    "Nimiq": false,
     "runKeyguard": false,
-    // Classes
+
+    // Libraries
     "AccountStore": false,
     "AddressUtils": false,
     "BrowserDetection": false,
     "CookieJar": false,
     "EncryptionType": false,
     "I18n": false,
-    "Identicon": false,
-    "Iqons": false,
     "Key": false,
     "KeyStore": false,
+    "RpcServer": false,
+    "TransactionType": false,
+    "Utf8Tools": false,
+
+    // Components
+    "Identicon": false,
+    "Iqons": false,
     "LanguagePicker": false,
-    "Nimiq": false,
     "PassphraseInput": false,
     "PinInput": false,
+
+    // Requests
     "PopupApi": false,
-    "RpcServer": false,
     "SignTransaction": false,
     "SignTransactionView": false,
     "SignTransactionWithPassphrase": false,
     "SignTransactionWithPin": false,
-    "TransactionType": false,
-    "Utf8Tools": false,
+
     // Errors
     "AmountTooSmallError": false,
     "InvalidAddressError": false,
     "NetworkMissmatchError": false,
     "TooManyAccountsSafariError": false,
     "TooManyAccountsIOSError": false
-
   },
   "rules": {
     "arrow-parens": ["error", "as-needed"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+      "browser": true
+  },
+  "extends": "airbnb-base",
+  "rules": {
+    "arrow-parens": ["error", "as-needed"],
+    "indent": ["error", 4],
+    "no-underscore-dangle": ["off"]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
     "max-len": ["error", 120],
     "no-param-reassign": ["off"],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-    "no-underscore-dangle": ["off"]
+    "no-underscore-dangle": ["off"],
+    "prefer-destructuring": ["off"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,8 @@
   },
   "extends": "airbnb-base",
   "globals": {
+    "runKeyguard": false,
+    // Classes
     "AccountStore": false,
     "AddressUtils": false,
     "BrowserDetection": false,
@@ -11,15 +13,28 @@
     "EncryptionType": false,
     "I18n": false,
     "Identicon": false,
-    "InvalidAddressError": false,
     "Iqons": false,
     "Key": false,
     "KeyStore": false,
     "LanguagePicker": false,
     "Nimiq": false,
+    "PassphraseInput": false,
+    "PinInput": false,
+    "PopupApi": false,
     "RpcServer": false,
+    "SignTransaction": false,
+    "SignTransactionView": false,
+    "SignTransactionWithPassphrase": false,
+    "SignTransactionWithPin": false,
     "TransactionType": false,
-    "Utf8Tools": false
+    "Utf8Tools": false,
+    // Errors
+    "AmountTooSmallError": false,
+    "InvalidAddressError": false,
+    "NetworkMissmatchError": false,
+    "TooManyAccountsSafariError": false,
+    "TooManyAccountsIOSError": false
+
   },
   "rules": {
     "arrow-parens": ["error", "as-needed"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
     "no-param-reassign": ["off"],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-underscore-dangle": ["off"],
-    "prefer-destructuring": ["off"]
+    "prefer-destructuring": ["off"],
+    "no-console": ["warn"]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ before_install:
   - CHROME_BIN=/usr/bin/google-chrome-stable
 
 script:
-  - npm run typecheck
-  - npm run test
+  - yarn typecheck
+  - yarn lint
+  - yarn test

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ Then you can:
 - run the tests with `npm run test` or `yarn test`.
 - run the typechecker with `npm run typecheck` or `yarn typecheck`.
 - run the typecheck file watcher with `npm run watch` or `yarn watch`.
+- run the linter with `npm run lint` or `yarn lint`.
+- automatically fix basic things like spacing, commas, indentation and quotes with `npm run lintfix` or `yarn lintfix`.
+- run `npm run pr` or `yarn pr` to run all three checks (`typecheck`, `lint`, `test`) as they would for a PR.
 
 ## Coding Style
-- Folder names in Kebab Case: `sign-transaction`
-- Class files are named in Pascal Case: `PinInput.js`, `RpcServer.js`
-- JSDoc @type and @param annotations must have a hyphen between argument name and description:
+- Code style is enforced with ESLint. Run `npm run lint` or `yarn lint` to see errors.
+- Folder names are in Kebab Case: `sign-transaction`.
+- Class files are named in Pascal Case: `PinInput.js`, `RpcServer.js`.
+- JSDoc @type and @param annotations must have a hyphen between the argument name and description:
 ```
 @param {string} address - The address to search for
 ```

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.0.1",
   "description": "Secure storage for Nimiq private keys.",
   "scripts": {
-    "test": "karma start",
+    "test": "tsc & eslint & karma start",
+    "karma": "karma start",
+    "typecheck": "tsc",
     "watch": "tsc --watch",
-    "typecheck": "tsc"
+    "lint": "eslint src/**/*.js",
+    "lintfix": "eslint --fix src/**/*.js"
   },
   "repository": {
     "type": "git",
@@ -23,6 +26,9 @@
   "homepage": "https://github.com/nimiq/keyguard-next#readme",
   "devDependencies": {
     "@types/jasmine": "^2.8.8",
+    "eslint": "^5.0.1",
+    "eslint-config-airbnb-base": "^13.0.0",
+    "eslint-plugin-import": "^2.13.0",
     "jasmine-core": "^3.1.0",
     "karma": "^2.0.4",
     "karma-chrome-launcher": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "test": "karma start",
     "typecheck": "tsc",
     "watch": "tsc --watch",
-    "lint": "eslint src/**/*.js",
-    "lintfix": "eslint --fix src/**/*.js"
+    "lint": "eslint src",
+    "lintfix": "eslint --fix src",
+    "pr": "tsc && eslint src && karma start"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.1",
   "description": "Secure storage for Nimiq private keys.",
   "scripts": {
-    "test": "tsc & eslint & karma start",
-    "karma": "karma start",
+    "test": "karma start",
     "typecheck": "tsc",
     "watch": "tsc --watch",
     "lint": "eslint src/**/*.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "karma start",
     "typecheck": "tsc",
-    "watch": "tsc --watch",
+    "watch": "tsc-watch --onSuccess \"eslint --fix src\"",
     "lint": "eslint src",
     "lintfix": "eslint --fix src",
     "pr": "tsc && eslint src && karma start"
@@ -33,6 +33,7 @@
     "karma": "^2.0.4",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.2",
+    "tsc-watch": "^1.0.22",
     "typescript": "^2.9.2"
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -2,8 +2,7 @@
  * @param {Function} RequestApiClass - Class object of the API which is to be exposed via postMessage RPC
  * @param {object} [options]
  */
-async function runKeyguard(RequestApiClass, options) {
-
+async function runKeyguard(RequestApiClass, options) { // eslint-disable-line no-unused-vars
     const defaultOptions = {
         loadNimiq: true,
         rpcWhitelist: ['request'],
@@ -12,7 +11,7 @@ async function runKeyguard(RequestApiClass, options) {
     options = Object.assign(defaultOptions, options);
 
     // Expose KeyStore to mockup overwrites
-    self.KeyStore = KeyStore;
+    window.KeyStore = KeyStore;
 
     if (options.loadNimiq) {
         // Load web assembly encryption library into browser (if supported)
@@ -22,12 +21,12 @@ async function runKeyguard(RequestApiClass, options) {
     }
 
     // Close window if user navigates back to loading screen
-    self.addEventListener('hashchange', () => {
-        if (location.hash === '') {
-            self.close();
+    window.addEventListener('hashchange', () => {
+        if (window.location.hash === '') {
+            window.close();
         }
     });
 
     // FIXME Set correct allowedOrigin
-    self.rpcServer = RpcServer.create(RequestApiClass, '*', options.rpcWhitelist); 
+    window.rpcServer = RpcServer.create(RequestApiClass, '*', options.rpcWhitelist);
 }

--- a/src/components/Identicon.js
+++ b/src/components/Identicon.js
@@ -1,4 +1,4 @@
-class Identicon {
+class Identicon { // eslint-disable-line no-unused-vars
     /**
      * @param {string} [address]
      * @param {HTMLImageElement} [el]

--- a/src/components/Identicon.js
+++ b/src/components/Identicon.js
@@ -1,5 +1,4 @@
 class Identicon {
-
     /**
      * @param {string} [address]
      * @param {HTMLImageElement} [el]

--- a/src/components/LanguagePicker.js
+++ b/src/components/LanguagePicker.js
@@ -1,4 +1,4 @@
-class LanguagePicker {
+class LanguagePicker { // eslint-disable-line no-unused-vars
     /**
      * @param {Element} [el]
      */
@@ -13,7 +13,7 @@ class LanguagePicker {
     _createElement() {
         const element = document.createElement('select');
 
-        for (const language of I18n.availableLanguages()) {
+        I18n.availableLanguages().forEach(language => {
             const label = I18n.translatePhrase('_language', language);
 
             const option = document.createElement('option');
@@ -25,7 +25,7 @@ class LanguagePicker {
             }
 
             element.appendChild(option);
-        }
+        });
 
         element.classList.add('i18n-language-picker');
         element.addEventListener('change', () => {

--- a/src/components/LanguagePicker.js
+++ b/src/components/LanguagePicker.js
@@ -1,5 +1,4 @@
 class LanguagePicker {
-
     /**
      * @param {Element} [el]
      */

--- a/src/components/PassphraseInput.js
+++ b/src/components/PassphraseInput.js
@@ -12,8 +12,8 @@ class PassphraseInput extends Nimiq.Observable {
         this.$eyeButton = /** @type {HTMLElement} */ (this.$el.querySelector('.eye-button'));
         this.$confirmButton = /** @type {HTMLButtonElement} */ (this.$el.querySelector('button'));
         this.$strengthIndicator = /** @type {HTMLElement} */ (this.$el.querySelector('.strength-indicator'));
-        this.$strengthIndicatorContainer =
-            /** @type {HTMLElement} */ (this.$el.querySelector('.strength-indicator-container'));
+        this.$strengthIndicatorContainer = /** @type {HTMLElement} */ (
+            this.$el.querySelector('.strength-indicator-container'));
 
         this.$el.addEventListener('submit', event => this._submit(event));
         this.$eyeButton.addEventListener('click', () => this._changeVisibility());
@@ -31,6 +31,7 @@ class PassphraseInput extends Nimiq.Observable {
         /** @type HTMLElement */
         const el = document.createElement('form');
         el.classList.add('passphrase-input');
+        /* eslint-disable */
         el.innerHTML = `
             <div class="input-container">
                 <input class="password" type="password" placeholder="Enter Passphrase" data-i18n-placeholder="passphrase-placeholder">
@@ -42,6 +43,7 @@ class PassphraseInput extends Nimiq.Observable {
             </div>
             <button data-i18n="passphrase-confirm"></button>
         `;
+        /* eslint-enable */
         I18n.translateDom(el);
         return el;
     }

--- a/src/components/PassphraseInput.js
+++ b/src/components/PassphraseInput.js
@@ -83,7 +83,7 @@ class PassphraseInput extends Nimiq.Observable {
         becomeVisible = typeof becomeVisible !== 'undefined'
             ? becomeVisible
             : this.$input.getAttribute('type') === 'password';
-        this.$input.setAttribute('type', becomeVisible? 'text' : 'password');
+        this.$input.setAttribute('type', becomeVisible ? 'text' : 'password');
         this.$eyeButton.classList.toggle('icon-eye-off', becomeVisible);
         this.$eyeButton.classList.toggle('icon-eye', !becomeVisible);
         this.$input.focus();
@@ -114,7 +114,7 @@ class PassphraseInput extends Nimiq.Observable {
 }
 
 PassphraseInput.Events = {
-    PASSPHRASE_ENTERED: 'passphrase-entered'
+    PASSPHRASE_ENTERED: 'passphrase-entered',
 };
 
 PassphraseInput.MIN_LENGTH = 10;

--- a/src/components/PinInput.js
+++ b/src/components/PinInput.js
@@ -75,7 +75,7 @@ class PinInput extends Nimiq.Observable {
     }
 
     get unlocking() {
-        return this._unlocking;
+        return !!this._unlocking;
     }
 
     onPinIncorrect() {
@@ -102,7 +102,7 @@ class PinInput extends Nimiq.Observable {
 
     /** @param {MouseEvent} e */
     _onClick(e) {
-        const target = /** @type {Element} */ (e.target); // eslint-disable-line prefer-destructuring
+        const target = /** @type {Element} */ (e.target);
         if (target.nodeName.toLowerCase() !== 'button' || target === this.$deleteButton) return;
         const key = parseInt(target.textContent || '', 10);
         this._onKeyPressed(key);
@@ -131,13 +131,12 @@ class PinInput extends Nimiq.Observable {
     }
 
     _setMaskedPin() {
-        const { length } = this._pin;
         /**
          * @param {Element} el
          * @param {number} i
          */
         const fillDot = (el, i) => {
-            if (i < length) {
+            if (i < this._pin.length) {
                 el.classList.add('on');
             } else {
                 el.classList.remove('on');

--- a/src/components/PinInput.js
+++ b/src/components/PinInput.js
@@ -81,7 +81,7 @@ class PinInput extends Nimiq.Observable {
     onPinIncorrect() {
         this.$el.classList.remove('unlocking');
         this.$el.classList.add('shake-pinpad');
-        this._attempts++;
+        this._attempts += 1;
         if (this._attempts === 3) {
             this._waitingTime *= this._waitingTime;
             this._attempts = 0;
@@ -92,8 +92,8 @@ class PinInput extends Nimiq.Observable {
     /** @param {KeyboardEvent} e */
     _handleKeyboardInput(e) {
         const inputCharString = e.key;
-        const inputNumber = parseInt(inputCharString);
-        if (isNaN(inputNumber)) {
+        const inputNumber = parseInt(inputCharString, 10);
+        if (Number.isNaN(inputNumber)) {
             e.preventDefault(); // stop character from entering input
         } else {
             this._onKeyPressed(inputNumber);
@@ -102,9 +102,9 @@ class PinInput extends Nimiq.Observable {
 
     /** @param {MouseEvent} e */
     _onClick(e) {
-        const target = /** @type {Element} */ (e.target);
+        const target = /** @type {Element} */ (e.target); // eslint-disable-line prefer-destructuring
         if (target.nodeName.toLowerCase() !== 'button' || target === this.$deleteButton) return;
-        const key = parseInt(target.textContent || '');
+        const key = parseInt(target.textContent || '', 10);
         this._onKeyPressed(key);
     }
 
@@ -131,7 +131,7 @@ class PinInput extends Nimiq.Observable {
     }
 
     _setMaskedPin() {
-        const length = this._pin.length;
+        const { length } = this._pin;
         /**
          * @param {Element} el
          * @param {number} i

--- a/src/components/PinInput.js
+++ b/src/components/PinInput.js
@@ -90,11 +90,11 @@ class PinInput extends Nimiq.Observable {
     }
 
     /** @param {KeyboardEvent} e */
-    _handleKeyboardInput (e) {
+    _handleKeyboardInput(e) {
         const inputCharString = e.key;
         const inputNumber = parseInt(inputCharString);
-        if (isNaN(inputNumber)){
-            e.preventDefault(); //stop character from entering input
+        if (isNaN(inputNumber)) {
+            e.preventDefault(); // stop character from entering input
         } else {
             this._onKeyPressed(inputNumber);
         }
@@ -148,5 +148,5 @@ class PinInput extends Nimiq.Observable {
 }
 
 PinInput.Events = {
-    PIN_ENTERED: 'pin-entered'
+    PIN_ENTERED: 'pin-entered',
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,17 +1,19 @@
+/* eslint-disable  no-unused-vars */
+
 /**
  * @typedef {Error & { code?: string }} CustomError
  */
 
 class KeyNotFoundError extends Error {
     constructor() {
-        super(`Key not found`);
+        super('Key not found');
         this.code = 'K1';
     }
 }
 
 class InvalidAddressError extends Error {
     constructor() {
-        super(`Invalid address`);
+        super('Invalid address');
         this.code = 'K2 ';
     }
 }
@@ -34,19 +36,18 @@ class TooManyAccountsIOSError extends Error {
 
 class AmountTooSmallError extends Error {
     constructor() {
-       super('Amount is too small');
-       this.code = 'K5';
+        super('Amount is too small');
+        this.code = 'K5';
     }
 }
 
 class NetworkMissmatchError extends Error {
-
     /** @param {string} transactionNetwork
      *  @param {string} keyguardNetwork
      */
     constructor(transactionNetwork, keyguardNetwork) {
-       super(`Network missmatch: ${transactionNetwork} in transaction, but ${keyguardNetwork} in Keyguard`);
-       this.code = 'K6';
+        super(`Network missmatch: ${transactionNetwork} in transaction, but ${keyguardNetwork} in Keyguard`);
+        this.code = 'K6';
     }
 }
 

--- a/src/lib/AccountStoreIndexeddb.js
+++ b/src/lib/AccountStoreIndexeddb.js
@@ -23,8 +23,6 @@ class AccountStore {
      */
     constructor(dbName = 'accounts') {
         this._dbName = dbName;
-        /** @type {IDBDatabase | undefined} */
-        this._db; // eslint-disable-line no-unused-expressions
         this._connected = false;
         this._dropped = false;
     }
@@ -41,6 +39,7 @@ class AccountStore {
 
             request.onsuccess = () => {
                 this._connected = true;
+                /** @type {IDBDatabase} */
                 this._db = request.result;
                 resolve(this._db);
             };

--- a/src/lib/AccountStoreIndexeddb.js
+++ b/src/lib/AccountStoreIndexeddb.js
@@ -11,7 +11,6 @@
  */
 
 class AccountStore {
-
     static get instance() {
         /** @type {AccountStore} */
         this._instance = this._instance || new AccountStore();
@@ -73,7 +72,7 @@ class AccountStore {
                     const keyInfo = {
                         address: key.userFriendlyAddress,
                         type: key.type,
-                        label: key.label
+                        label: key.label,
                     };
 
                     results.push(keyInfo);

--- a/src/lib/AccountStoreIndexeddb.js
+++ b/src/lib/AccountStoreIndexeddb.js
@@ -24,7 +24,7 @@ class AccountStore {
     constructor(dbName = 'accounts') {
         this._dbName = dbName;
         /** @type {IDBDatabase | undefined} */
-        this._db;
+        this._db; // eslint-disable-line no-unused-expressions
         this._connected = false;
         this._dropped = false;
     }
@@ -37,7 +37,7 @@ class AccountStore {
         if (this._connected && this._db) return Promise.resolve(this._db);
 
         return new Promise((resolve, reject) => {
-            const request = self.indexedDB.open(this._dbName, AccountStore.VERSION);
+            const request = window.indexedDB.open(this._dbName, AccountStore.VERSION);
 
             request.onsuccess = () => {
                 this._connected = true;
@@ -68,14 +68,15 @@ class AccountStore {
                 if (cursor) {
                     const key = cursor.value;
 
-                    // Because: To use Key.getPublicInfo(), we would need to create Key instances out of the key object that we receive from the DB.
-                    const keyInfo = {
+                    // Because: To use Key.getPublicInfo(), we would need to create Key
+                    // instances out of the key object that we receive from the DB.
+                    const accountInfo = {
                         address: key.userFriendlyAddress,
                         type: key.type,
                         label: key.label,
                     };
 
-                    results.push(keyInfo);
+                    results.push(accountInfo);
                     cursor.continue();
                 } else {
                     resolve(results);
@@ -123,7 +124,7 @@ class AccountStore {
         if (this._connected) this.close();
 
         return new Promise((resolve, reject) => {
-            const request = self.indexedDB.deleteDatabase(this._dbName);
+            const request = window.indexedDB.deleteDatabase(this._dbName);
 
             request.onsuccess = () => {
                 this._dropped = true;

--- a/src/lib/AddressUtils.js
+++ b/src/lib/AddressUtils.js
@@ -53,7 +53,7 @@ class AddressUtils { // eslint-disable-line no-unused-vars
             throw new Error('Addresses are 36 chars (ignoring spaces)');
         }
 
-        if (!this._alphabetCheck(str.toUpperCase())) {
+        if (!this._alphabetCheck(str)) {
             throw new Error('Address has invalid characters');
         }
 
@@ -66,9 +66,11 @@ class AddressUtils { // eslint-disable-line no-unused-vars
      * @param {string} str
      */
     static _alphabetCheck(str) {
-        const filteredStr = str.split('').filter(c => AddressUtils.NIMIQ_ALPHABET.includes(c)).join('');
-
-        return filteredStr === str;
+        str = str.toUpperCase();
+        for (let i = 0; i < str.length; i++) {
+            if (!AddressUtils.NIMIQ_ALPHABET.includes(str[i])) return false;
+        }
+        return true;
     }
 
     /**

--- a/src/lib/AddressUtils.js
+++ b/src/lib/AddressUtils.js
@@ -1,10 +1,14 @@
 /**
  * Usage:
  * <script src="lib/address-utils.js"></script>
- * const isValidAddress = AddressUtils.isValidAddress('NQ12 3456 7890 ABCD EFGH IJKL MNOP QRST UVWX'); // false
- * const formattedAddress = Address.Utils.formatAddress(' NQ 1234567890A BCDEFGHIJKLMN  OPQRSTUVWX '); // 'NQ12 3456 7890 ABCD EFGH IJKL MNOP QRST UVWX'
+ *
+ * const isValidAddress = AddressUtils.isValidAddress('NQ12 3456 7890 ABCD EFGH IJKL MNOP QRST UVWX');
+ * // returns FALSE
+ *
+ * const formattedAddress = Address.Utils.formatAddress(' NQ 1234567890A BCDEFGHIJKLMN  OPQRSTUVWX ');
+ * // returns 'NQ12 3456 7890 ABCD EFGH IJKL MNOP QRST UVWX'
  */
-class AddressUtils {
+class AddressUtils { // eslint-disable-line no-unused-vars
     /**
      * IBAN-format Nimiq address
      * @param {string} str
@@ -79,10 +83,10 @@ class AddressUtils {
         let tmp = '';
 
         for (let i = 0; i < Math.ceil(num.length / 6); i++) {
-            tmp = (parseInt(tmp + num.substr(i * 6, 6)) % 97).toString();
+            tmp = (parseInt(tmp + num.substr(i * 6, 6), 10) % 97).toString();
         }
 
-        return parseInt(tmp);
+        return parseInt(tmp, 10);
     }
 
     static get NIMIQ_ALPHABET() {

--- a/src/lib/AddressUtils.js
+++ b/src/lib/AddressUtils.js
@@ -5,7 +5,6 @@
  * const formattedAddress = Address.Utils.formatAddress(' NQ 1234567890A BCDEFGHIJKLMN  OPQRSTUVWX '); // 'NQ12 3456 7890 ABCD EFGH IJKL MNOP QRST UVWX'
  */
 class AddressUtils {
-
     /**
      * IBAN-format Nimiq address
      * @param {string} str
@@ -63,9 +62,7 @@ class AddressUtils {
      * @param {string} str
      */
     static _alphabetCheck(str) {
-        const filteredStr = str.split('').filter((c) => {
-            return AddressUtils.NIMIQ_ALPHABET.includes(c);
-        }).join('');
+        const filteredStr = str.split('').filter(c => AddressUtils.NIMIQ_ALPHABET.includes(c)).join('');
 
         return filteredStr === str;
     }
@@ -74,7 +71,7 @@ class AddressUtils {
      * @param {string} str
      */
     static _ibanCheck(str) {
-        const num = str.split('').map((c) => {
+        const num = str.split('').map(c => {
             const code = c.toUpperCase().charCodeAt(0);
             return code >= 48 && code <= 57 ? c : (code - 55).toString();
         }).join('');

--- a/src/lib/BrowserDetection.js
+++ b/src/lib/BrowserDetection.js
@@ -1,11 +1,11 @@
-class BrowserDetection {
+class BrowserDetection { // eslint-disable-line no-unused-vars
     static isDesktopSafari() {
         // see https://stackoverflow.com/a/23522755
         return /^((?!chrome|android).)*safari/i.test(navigator.userAgent) && !/mobile/i.test(navigator.userAgent);
     }
 
     static isSafari() {
-        return !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);
+        return !!navigator.userAgent.match(/Version\/[\d.]+.*Safari/);
     }
 
     static isIos() {

--- a/src/lib/BrowserDetection.js
+++ b/src/lib/BrowserDetection.js
@@ -1,5 +1,4 @@
 class BrowserDetection {
-
     static isDesktopSafari() {
         // see https://stackoverflow.com/a/23522755
         return /^((?!chrome|android).)*safari/i.test(navigator.userAgent) && !/mobile/i.test(navigator.userAgent);
@@ -16,7 +15,7 @@ class BrowserDetection {
 
     static iosVersion() {
         if (BrowserDetection.isIos()) {
-            var v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+            const v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
             if (v) {
                 return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || '0', 10)];
             }
@@ -27,6 +26,6 @@ class BrowserDetection {
 
     static isBadIos() {
         const version = this.iosVersion();
-        return version[0] < 11 || (version[0] === 11 && version[1] === 2) // Only 11.2 has the WASM bug
+        return version[0] < 11 || (version[0] === 11 && version[1] === 2); // Only 11.2 has the WASM bug
     }
 }

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -1,4 +1,4 @@
-class CookieJar {
+class CookieJar { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyInfo[]} keys
      */
@@ -35,13 +35,11 @@ class CookieJar {
      * @param {KeyInfo[]} keys
      */
     static _encodeCookie(keys) {
-        let str = '';
-
-        for (const keyInfo of keys) {
+        const str = keys.map(keyInfo => {
             const address = Nimiq.Address.fromUserFriendlyAddress(keyInfo.userFriendlyAddress);
             const encodedAddress = /** @type {string} */ (address.toBase64());
-            str += keyInfo.type.toString() + encodedAddress.slice(0, 27);
-        }
+            return keyInfo.type.toString() + encodedAddress.slice(0, 27);
+        }).join('');
 
         return str;
     }
@@ -59,7 +57,7 @@ class CookieJar {
         if (!keys) return []; // Make TS happy (match() can potentially return NULL)
 
         return keys.map(key => {
-            const type = parseInt(key[0]);
+            const type = parseInt(key[0], 10);
             const userFriendlyAddress = Nimiq.Address.fromBase64(key.substr(1)).toUserFriendlyAddress();
 
             return /** @type {KeyInfo} */ ({

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -1,5 +1,4 @@
 class CookieJar {
-
     /**
      * @param {KeyInfo[]} keys
      */
@@ -65,7 +64,7 @@ class CookieJar {
 
             return /** @type {KeyInfo} */ ({
                 userFriendlyAddress,
-                type
+                type,
             });
         });
     }

--- a/src/lib/EncryptionType.js
+++ b/src/lib/EncryptionType.js
@@ -1,5 +1,5 @@
 /** @typedef {1 | 2} EncryptionType */
 const EncryptionType = {
     LOW: /** @type {1} */ (1),
-    HIGH: /** @type {2} */ (2)
+    HIGH: /** @type {2} */ (2),
 };

--- a/src/lib/EncryptionType.js
+++ b/src/lib/EncryptionType.js
@@ -1,5 +1,5 @@
 /** @typedef {1 | 2} EncryptionType */
-const EncryptionType = {
+const EncryptionType = { // eslint-disable-line no-unused-vars
     LOW: /** @type {1} */ (1),
     HIGH: /** @type {2} */ (2),
 };

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -12,9 +12,6 @@ class I18n { // eslint-disable-line no-unused-vars
         /** @type {string} */
         this._fallbackLanguage = fallbackLanguage;
 
-        /** @type {string} */
-        this._language = '';
-
         this.language = navigator.language;
     }
 

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -1,4 +1,4 @@
-class I18n {
+class I18n { // eslint-disable-line no-unused-vars
     /**
      * @param {object} dictionary - dictionary of all languages and phrases
      * @param {string} fallbackLanguage - Language to be used if no translation for the current language can be found.
@@ -13,21 +13,22 @@ class I18n {
         this._fallbackLanguage = fallbackLanguage;
 
         /** @type {string} */
-        this._language;
+        this._language = '';
 
         this.language = navigator.language;
     }
 
     /**
      * @param {HTMLElement} [dom] - The DOM element to be translated, or body by default
-     * @param {string} [enforcedLanguage] - ISO code of language to translate to, or the currently selected language by default
+     * @param {string} [enforcedLanguage] - ISO code of language to translate to
      */
     static translateDom(dom = document.body, enforcedLanguage) {
         const language = enforcedLanguage ? this.getClosestSupportedLanguage(enforcedLanguage) : this.language;
 
         /**
          * @param {string} tag
-         * @param {(element: HTMLElement, translation: string) => void} callback - callback(element, translation) for each matching element
+         * @param {(element: HTMLElement, translation: string) => void} callback
+         *    - callback(element, translation) for each matching element
          */
         const translateElements = (tag, callback) => {
             const attribute = `data-${tag}`;
@@ -47,14 +48,14 @@ class I18n {
             translateElements(`i18n-${tag}`, (element, translation) => element.setAttribute(tag, translation));
         };
 
-        translateElements('i18n', (element, translation) => element.textContent = translation);
+        translateElements('i18n', (element, translation) => { element.textContent = translation; });
         translateAttribute('value');
         translateAttribute('placeholder');
     }
 
     /**
      * @param {string} id - translation dict ID
-     * @param {string} [enforcedLanguage] - ISO code of language to translate to, or the currently selected language by default
+     * @param {string} [enforcedLanguage] - ISO code of language to translate to
      */
     static translatePhrase(id, enforcedLanguage) {
         const language = enforcedLanguage ? this.getClosestSupportedLanguage(enforcedLanguage) : this.language;
@@ -91,20 +92,19 @@ class I18n {
      * @returns {string}
      */
     static getClosestSupportedLanguage(language) {
+        // If this language is supported, return it directly
         if (language in this._dict) return language;
 
+        // Return the base language, if it exists in the dictionary
         const baseLanguage = language.split('-')[0];
-
-        // Return the the base language, if it exists in the dictionary
         if (baseLanguage !== language && baseLanguage in this._dict) return baseLanguage;
 
-        // Check if other versions of the base language exist
+        // Check if other versions (siblings) of the base language exist
         const languagePrefix = `${baseLanguage}-`;
-        for (const supportedLanguage of this.availableLanguages()) {
-            if (supportedLanguage.startsWith(languagePrefix)) return supportedLanguage;
-        }
+        const siblingLanguage = this.availableLanguages()
+            .find(supportedLanguage => supportedLanguage.startsWith(languagePrefix));
 
-        return this.fallbackLanguage;
+        return siblingLanguage || this.fallbackLanguage;
     }
 
     /**
@@ -114,6 +114,7 @@ class I18n {
         const languageToUse = this.getClosestSupportedLanguage(language);
 
         if (languageToUse !== language) {
+            // eslint-disable-next-line no-console
             console.warn(`Language ${language} not supported, using ${languageToUse} instead.`);
         }
 
@@ -121,7 +122,7 @@ class I18n {
     }
 
     static get language() {
-        return this._language;
+        return this._language || this.fallbackLanguage;
     }
 
     static get dictionary() {

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -111,7 +111,6 @@ class I18n { // eslint-disable-line no-unused-vars
         const languageToUse = this.getClosestSupportedLanguage(language);
 
         if (languageToUse !== language) {
-            // eslint-disable-next-line no-console
             console.warn(`Language ${language} not supported, using ${languageToUse} instead.`);
         }
 

--- a/src/lib/I18n.js
+++ b/src/lib/I18n.js
@@ -1,5 +1,4 @@
 class I18n {
-
     /**
      * @param {object} dictionary - dictionary of all languages and phrases
      * @param {string} fallbackLanguage - Language to be used if no translation for the current language can be found.
@@ -8,7 +7,7 @@ class I18n {
         this._dict = dictionary;
 
         if (!(fallbackLanguage in this._dict)) {
-            throw new Error(`Fallback language "${ fallbackLanguage }" not defined`);
+            throw new Error(`Fallback language "${fallbackLanguage}" not defined`);
         }
         /** @type {string} */
         this._fallbackLanguage = fallbackLanguage;
@@ -22,7 +21,7 @@ class I18n {
     /**
      * @param {HTMLElement} [dom] - The DOM element to be translated, or body by default
      * @param {string} [enforcedLanguage] - ISO code of language to translate to, or the currently selected language by default
-     **/
+     */
     static translateDom(dom = document.body, enforcedLanguage) {
         const language = enforcedLanguage ? this.getClosestSupportedLanguage(enforcedLanguage) : this.language;
 
@@ -33,20 +32,20 @@ class I18n {
         const translateElements = (tag, callback) => {
             const attribute = `data-${tag}`;
             /** @type {NodeListOf<HTMLElement>} */
-            const elements = dom.querySelectorAll(`[${ attribute }]`);
+            const elements = dom.querySelectorAll(`[${attribute}]`);
             elements.forEach(element => {
                 const id = element.getAttribute(attribute);
                 if (!id) return;
                 callback(element, this._translate(id, language));
             });
-        }
+        };
 
         /**
          * @param {string} tag
          */
-        const translateAttribute = (tag) => {
-            translateElements(`i18n-${ tag }`, (element, translation) => element.setAttribute(tag, translation));
-        }
+        const translateAttribute = tag => {
+            translateElements(`i18n-${tag}`, (element, translation) => element.setAttribute(tag, translation));
+        };
 
         translateElements('i18n', (element, translation) => element.textContent = translation);
         translateAttribute('value');

--- a/src/lib/Iqons.js
+++ b/src/lib/Iqons.js
@@ -1,5 +1,4 @@
 class Iqons {
-
     /* Public API */
 
     /**
@@ -14,7 +13,7 @@ class Iqons {
             parseInt(hash[5] + hash[6]),
             parseInt(hash[7] + hash[8]),
             parseInt(hash[9] + hash[10]),
-            parseInt(hash[11])
+            parseInt(hash[11]),
         );
     }
 
@@ -75,11 +74,9 @@ class Iqons {
      * @param {number} accentColor
      */
     static async _$iqons(color, backgroundColor, faceNr, topNr, sidesNr, bottomNr, accentColor) {
-        if (color === backgroundColor)
-            if (++color > 9) color = 0;
+        if (color === backgroundColor) if (++color > 9) color = 0;
 
-        while (accentColor === color || accentColor === backgroundColor)
-            if (++accentColor > 9) accentColor = 0;
+        while (accentColor === color || accentColor === backgroundColor) if (++accentColor > 9) accentColor = 0;
 
         const colorString = this.colors[color];
         const backgroundColorString = this.colors[backgroundColor];
@@ -100,18 +97,17 @@ class Iqons {
      * @param {string} content
      */
     static _$svg(content) {
-
         const randomId = this._getRandomId();
         return `<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
     <defs>
-        <clipPath id="hexagon-clip-${ randomId }" transform="scale(0.5) translate(0, 16)">
+        <clipPath id="hexagon-clip-${randomId}" transform="scale(0.5) translate(0, 16)">
             <path d="M251.6 17.34l63.53 110.03c5.72 9.9 5.72 22.1 0 32L251.6 269.4c-5.7 9.9-16.27 16-27.7 16H96.83c-11.43 0-22-6.1-27.7-16L5.6 159.37c-5.7-9.9-5.7-22.1 0-32L69.14 17.34c5.72-9.9 16.28-16 27.7-16H223.9c11.43 0 22 6.1 27.7 16z"/>
         </clipPath>
     </defs>
     <path fill="white" stroke="#bbbbbb" transform="translate(0, 8) scale(0.5)" d="M251.6 17.34l63.53 110.03c5.72 9.9 5.72 22.1 0 32L251.6 269.4c-5.7 9.9-16.27 16-27.7 16H96.83c-11.43 0-22-6.1-27.7-16L5.6 159.37c-5.7-9.9-5.7-22.1 0-32L69.14 17.34c5.72-9.9 16.28-16 27.7-16H223.9c11.43 0 22 6.1 27.7 16z"/>
     <g transform="scale(0.9) translate(9, 8)">
-        <g clip-path="url(#hexagon-clip-${ randomId })">
-            ${ content }
+        <g clip-path="url(#hexagon-clip-${randomId})">
+            ${content}
         </g>
     </g>
 </svg>`;
@@ -123,7 +119,7 @@ class Iqons {
      */
     static async _generatePart(part, index) {
         const assets = await this._getAssets();
-        const selector = '#' + part + '_' + this._assetIndex(index, part);
+        const selector = `#${part}_${this._assetIndex(index, part)}`;
         const $part = assets.querySelector(selector);
         return $part && $part.innerHTML;
     }
@@ -134,7 +130,7 @@ class Iqons {
             .then(response => response.text())
             .then(assetsText => {
                 const parser = new DOMParser();
-                const assets = parser.parseFromString(assetsText, "image/svg+xml");
+                const assets = parser.parseFromString(assetsText, 'image/svg+xml');
                 this._assets = assets;
                 return assets;
             });
@@ -151,17 +147,17 @@ class Iqons {
             '#009688', // teal-500
             '#f06292', // pink-300
             '#7cb342', // light-green-600
-            '#795548'  // brown-400
-        ]
+            '#795548', // brown-400
+        ];
     }
 
     static get assetCounts() {
         return {
-            'face': Iqons.CATALOG.face.length,
-            'side': Iqons.CATALOG.side.length,
-            'top': Iqons.CATALOG.top.length,
-            'bottom': Iqons.CATALOG.bottom.length
-        }
+            face: Iqons.CATALOG.face.length,
+            side: Iqons.CATALOG.side.length,
+            top: Iqons.CATALOG.top.length,
+            bottom: Iqons.CATALOG.bottom.length,
+        };
     }
 
     /**
@@ -172,8 +168,8 @@ class Iqons {
     static _assetIndex(index, part) {
         index = (index % this.assetCounts[part]) + 1;
         let fullIndex = index.toString();
-        if (index < 10) fullIndex = '0' + fullIndex;
-        return fullIndex
+        if (index < 10) fullIndex = `0${fullIndex}`;
+        return fullIndex;
     }
 
     /**
@@ -181,10 +177,10 @@ class Iqons {
      * @returns {string}
      */
     static _hash(text) {
-        return ('' + text
-                .split('')
-                .map(c => Number(c.charCodeAt(0)) + 3)
-                .reduce((a, e) => a * (1 - a) * this._chaosHash(e), 0.5))
+        return (`${text
+            .split('')
+            .map(c => Number(c.charCodeAt(0)) + 3)
+            .reduce((a, e) => a * (1 - a) * this._chaosHash(e), 0.5)}`)
             .split('')
             .reduce((a, e) => e + a, '')
             .substr(4, 17);
@@ -207,7 +203,7 @@ class Iqons {
      * @returns {number}
      */
     static _getRandomId() {
-        let array = new Uint32Array(1);
+        const array = new Uint32Array(1);
         crypto.getRandomValues(array);
         return array[0];
     }
@@ -216,8 +212,8 @@ class Iqons {
 Iqons.svgPath = '/apps/keyguard-next/src/lib/Iqons.min.svg';
 
 Iqons.CATALOG = {
-    face : ['face_01','face_02','face_03','face_04','face_05','face_06','face_07','face_08','face_09','face_10','face_11','face_12','face_13','face_14','face_15','face_16','face_17','face_18','face_19','face_20','face_21',],
-    side : ['side_01','side_02','side_03','side_04','side_05','side_06','side_07','side_08','side_09','side_10','side_11','side_12','side_13','side_14','side_15','side_16','side_17','side_18','side_19','side_20','side_21',],
-    top : ['top_01','top_02','top_03','top_04','top_05','top_06','top_07','top_08','top_09','top_10','top_11','top_12','top_13','top_14','top_15','top_16','top_17','top_18','top_19','top_20','top_21',],
-    bottom : ['bottom_01','bottom_02','bottom_03','bottom_04','bottom_05','bottom_06','bottom_07','bottom_08','bottom_09','bottom_10','bottom_11','bottom_12','bottom_13','bottom_14','bottom_15','bottom_16','bottom_17','bottom_18','bottom_19','bottom_20','bottom_21',],
-}
+    face: ['face_01', 'face_02', 'face_03', 'face_04', 'face_05', 'face_06', 'face_07', 'face_08', 'face_09', 'face_10', 'face_11', 'face_12', 'face_13', 'face_14', 'face_15', 'face_16', 'face_17', 'face_18', 'face_19', 'face_20', 'face_21'],
+    side: ['side_01', 'side_02', 'side_03', 'side_04', 'side_05', 'side_06', 'side_07', 'side_08', 'side_09', 'side_10', 'side_11', 'side_12', 'side_13', 'side_14', 'side_15', 'side_16', 'side_17', 'side_18', 'side_19', 'side_20', 'side_21'],
+    top: ['top_01', 'top_02', 'top_03', 'top_04', 'top_05', 'top_06', 'top_07', 'top_08', 'top_09', 'top_10', 'top_11', 'top_12', 'top_13', 'top_14', 'top_15', 'top_16', 'top_17', 'top_18', 'top_19', 'top_20', 'top_21'],
+    bottom: ['bottom_01', 'bottom_02', 'bottom_03', 'bottom_04', 'bottom_05', 'bottom_06', 'bottom_07', 'bottom_08', 'bottom_09', 'bottom_10', 'bottom_11', 'bottom_12', 'bottom_13', 'bottom_14', 'bottom_15', 'bottom_16', 'bottom_17', 'bottom_18', 'bottom_19', 'bottom_20', 'bottom_21'],
+};

--- a/src/lib/Iqons.js
+++ b/src/lib/Iqons.js
@@ -7,13 +7,13 @@ class Iqons {
     static async svg(text) {
         const hash = this._hash(text);
         return this._svgTemplate(
-            parseInt(hash[0]),
-            parseInt(hash[2]),
-            parseInt(hash[3] + hash[4]),
-            parseInt(hash[5] + hash[6]),
-            parseInt(hash[7] + hash[8]),
-            parseInt(hash[9] + hash[10]),
-            parseInt(hash[11]),
+            parseInt(hash[0], 10),
+            parseInt(hash[2], 10),
+            parseInt(hash[3] + hash[4], 10),
+            parseInt(hash[5] + hash[6], 10),
+            parseInt(hash[7] + hash[8], 10),
+            parseInt(hash[9] + hash[10], 10),
+            parseInt(hash[11], 10),
         );
     }
 
@@ -32,6 +32,7 @@ class Iqons {
     static placeholder(color, strokeWidth) {
         color = color || '#bbb';
         strokeWidth = strokeWidth || 1;
+        /* eslint-disable */
         return `<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
     <path fill="none" stroke="${color}" stroke-width="${2 * strokeWidth}" transform="translate(0, 8) scale(0.5)" d="M251.6 17.34l63.53 110.03c5.72 9.9 5.72 22.1 0 32L251.6 269.4c-5.7 9.9-16.27 16-27.7 16H96.83c-11.43 0-22-6.1-27.7-16L5.6 159.37c-5.7-9.9-5.7-22.1 0-32L69.14 17.34c5.72-9.9 16.28-16 27.7-16H223.9c11.43 0 22 6.1 27.7 16z"/>
     <g transform="scale(0.9) translate(9, 8)">
@@ -39,6 +40,7 @@ class Iqons {
         <g opacity=".1" fill="#010101"><path d="M119.21,80a39.46,39.46,0,0,1-67.13,28.13c10.36,2.33,36,3,49.82-14.28,10.39-12.47,8.31-33.23,4.16-43.26A39.35,39.35,0,0,1,119.21,80Z"/></g>\`
     </g>
 </svg>`;
+        /* eslint-enable */
     }
 
     /**
@@ -74,14 +76,21 @@ class Iqons {
      * @param {number} accentColor
      */
     static async _$iqons(color, backgroundColor, faceNr, topNr, sidesNr, bottomNr, accentColor) {
-        if (color === backgroundColor) if (++color > 9) color = 0;
+        if (color === backgroundColor) {
+            color += 1;
+            if (color > 9) color = 0;
+        }
 
-        while (accentColor === color || accentColor === backgroundColor) if (++accentColor > 9) accentColor = 0;
+        while (accentColor === color || accentColor === backgroundColor) {
+            accentColor += 1;
+            if (accentColor > 9) accentColor = 0;
+        }
 
         const colorString = this.colors[color];
         const backgroundColorString = this.colors[backgroundColor];
         const accentColorString = this.colors[accentColor];
 
+        /* eslint-disable */
         return `<g color="${colorString}" fill="${accentColorString}">
     <rect fill="${backgroundColorString}" x="0" y="0" width="160" height="160"></rect>
     <circle cx="80" cy="80" r="40" fill="${colorString}"></circle>
@@ -91,6 +100,7 @@ class Iqons {
     ${await this._generatePart('face', faceNr)}
     ${await this._generatePart('bottom', bottomNr)}
 </g>`;
+        /* eslint-enable */
     }
 
     /**
@@ -98,6 +108,7 @@ class Iqons {
      */
     static _$svg(content) {
         const randomId = this._getRandomId();
+        /* eslint-disable */
         return `<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
     <defs>
         <clipPath id="hexagon-clip-${randomId}" transform="scale(0.5) translate(0, 16)">
@@ -111,6 +122,7 @@ class Iqons {
         </g>
     </g>
 </svg>`;
+        /* eslint-enable */
     }
 
     /**
@@ -192,11 +204,11 @@ class Iqons {
      */
     static _chaosHash(number) {
         const k = 3.569956786876;
-        let a_n = 1 / number;
+        let an = 1 / number;
         for (let i = 0; i < 100; i++) {
-            a_n = (1 - a_n) * a_n * k;
+            an = (1 - an) * an * k;
         }
-        return a_n;
+        return an;
     }
 
     /**
@@ -212,8 +224,24 @@ class Iqons {
 Iqons.svgPath = '/apps/keyguard-next/src/lib/Iqons.min.svg';
 
 Iqons.CATALOG = {
-    face: ['face_01', 'face_02', 'face_03', 'face_04', 'face_05', 'face_06', 'face_07', 'face_08', 'face_09', 'face_10', 'face_11', 'face_12', 'face_13', 'face_14', 'face_15', 'face_16', 'face_17', 'face_18', 'face_19', 'face_20', 'face_21'],
-    side: ['side_01', 'side_02', 'side_03', 'side_04', 'side_05', 'side_06', 'side_07', 'side_08', 'side_09', 'side_10', 'side_11', 'side_12', 'side_13', 'side_14', 'side_15', 'side_16', 'side_17', 'side_18', 'side_19', 'side_20', 'side_21'],
-    top: ['top_01', 'top_02', 'top_03', 'top_04', 'top_05', 'top_06', 'top_07', 'top_08', 'top_09', 'top_10', 'top_11', 'top_12', 'top_13', 'top_14', 'top_15', 'top_16', 'top_17', 'top_18', 'top_19', 'top_20', 'top_21'],
-    bottom: ['bottom_01', 'bottom_02', 'bottom_03', 'bottom_04', 'bottom_05', 'bottom_06', 'bottom_07', 'bottom_08', 'bottom_09', 'bottom_10', 'bottom_11', 'bottom_12', 'bottom_13', 'bottom_14', 'bottom_15', 'bottom_16', 'bottom_17', 'bottom_18', 'bottom_19', 'bottom_20', 'bottom_21'],
+    face: [
+        'face_01', 'face_02', 'face_03', 'face_04', 'face_05', 'face_06', 'face_07',
+        'face_08', 'face_09', 'face_10', 'face_11', 'face_12', 'face_13', 'face_14',
+        'face_15', 'face_16', 'face_17', 'face_18', 'face_19', 'face_20', 'face_21',
+    ],
+    side: [
+        'side_01', 'side_02', 'side_03', 'side_04', 'side_05', 'side_06', 'side_07',
+        'side_08', 'side_09', 'side_10', 'side_11', 'side_12', 'side_13', 'side_14',
+        'side_15', 'side_16', 'side_17', 'side_18', 'side_19', 'side_20', 'side_21',
+    ],
+    top: [
+        'top_01', 'top_02', 'top_03', 'top_04', 'top_05', 'top_06', 'top_07',
+        'top_08', 'top_09', 'top_10', 'top_11', 'top_12', 'top_13', 'top_14',
+        'top_15', 'top_16', 'top_17', 'top_18', 'top_19', 'top_20', 'top_21',
+    ],
+    bottom: [
+        'bottom_01', 'bottom_02', 'bottom_03', 'bottom_04', 'bottom_05', 'bottom_06', 'bottom_07',
+        'bottom_08', 'bottom_09', 'bottom_10', 'bottom_11', 'bottom_12', 'bottom_13', 'bottom_14',
+        'bottom_15', 'bottom_16', 'bottom_17', 'bottom_18', 'bottom_19', 'bottom_20', 'bottom_21',
+    ],
 };

--- a/src/lib/Key.js
+++ b/src/lib/Key.js
@@ -13,7 +13,6 @@
  * const msg = key.signMessage('message');
  *
  */
-/// <reference path="EncryptionType.js" />
 class Key {
     /**
      * @param {Uint8Array | string} buf - Keypair, as byte array or HEX string
@@ -83,7 +82,7 @@ class Key {
      * @returns {object}
      */
     signMessage(message) {
-        message = 'nimiq_msg_' + message;
+        message = `nimiq_msg_${message}`;
         const msgBytes = Utf8Tools.stringToUtf8ByteArray(message);
         const signature = Nimiq.Signature.create(this.keyPair.privateKey, this.keyPair.publicKey, msgBytes);
         return { message, signature };
@@ -171,7 +170,7 @@ class Key {
             fee,
             validityStartHeight,
             isContractCreation ? Nimiq.Transaction.Flag.CONTRACT_CREATION : Nimiq.Transaction.Flag.NONE,
-            extraData
+            extraData,
         );
 
         const proof = this._makeSignatureProof(transaction.serializeContent());
@@ -262,8 +261,8 @@ class Key {
     getPublicInfo() {
         return {
             userFriendlyAddress: this.userFriendlyAddress,
-            type: this.type
-        }
+            type: this.type,
+        };
     }
 
     /**

--- a/src/lib/Key.js
+++ b/src/lib/Key.js
@@ -8,12 +8,15 @@
  * const tx = key.createTransaction(recipient, value, fee, validityStartHeight);
  * const tx = key.createTransactionWithMessage(recipient, value, fee, validityStartHeight, message);
  * const tx = key.createVestingPayoutTransaction(sender, value, fee, validityStartHeight, [message]);
- * const tx = key.createExtendedTransaction(sender, [senderType], recipient, [recipientType], value, fee, validityStartHeight, [extraData], [isContractCreation]);
+ * const tx = key.createExtendedTransaction(
+ *    sender, [senderType], recipient, [recipientType],
+ *    value, fee, validityStartHeight, [extraData], [isContractCreation]
+ * );
  *
  * const msg = key.signMessage('message');
  *
  */
-class Key {
+class Key { // eslint-disable-line no-unused-vars
     /**
      * @param {Uint8Array | string} buf - Keypair, as byte array or HEX string
      * @param {EncryptionType} type
@@ -95,14 +98,16 @@ class Key {
      * @param {number} value - Number of satoshis to send
      * @param {number} fee - Number of satoshis to set as fee
      * @param {number} validityStartHeight - The validityStartHeight for the transaction
-     * @returns {Nimiq.BasicTransaction} A prepared and signed Transaction object (this still has to be sent to the network)
+     * @returns {Nimiq.BasicTransaction} A prepared and signed Transaction object (to be sent to the network)
      */
     createTransaction(recipient, value, fee, validityStartHeight) {
         if (typeof recipient === 'string') {
             recipient = Key.getUnfriendlyAddress(recipient);
         }
 
-        const transaction = new Nimiq.BasicTransaction(this.keyPair.publicKey, recipient, value, fee, validityStartHeight);
+        const transaction = new Nimiq.BasicTransaction(
+            this.keyPair.publicKey, recipient, value, fee, validityStartHeight,
+        );
         const proof = this._makeSignatureProof(transaction.serializeContent());
         transaction.proof = proof.serialize();
         return transaction;
@@ -116,24 +121,32 @@ class Key {
      * @param {number} fee - Number of satoshis to set as fee
      * @param {number} validityStartHeight - The validityStartHeight for the transaction
      * @param {string} message - Message to add to the transaction
-     * @returns {Nimiq.ExtendedTransaction} A prepared and signed Transaction object (this still has to be sent to the network)
+     * @returns {Nimiq.ExtendedTransaction} A prepared and signed Transaction object (to be sent to the network)
      */
     createTransactionWithMessage(recipient, value, fee, validityStartHeight, message) {
-        return this.createExtendedTransaction(this.publicKey.toAddress(), null, recipient, null, value, fee, validityStartHeight, message);
+        return this.createExtendedTransaction(
+            this.publicKey.toAddress(), null,
+            recipient, null,
+            value, fee, validityStartHeight, message,
+        );
     }
 
     /**
      * Create an extended transaction that pays out vested NIM to this key and that is signed by this key.
      *
      * @param {Nimiq.Address | string} sender - Address of the transaction sending vesting contract
-     * @param {number} value - Number of Satoshis to send.
-     * @param {number} fee Number of Satoshis to donate to the Miner.
-     * @param {number} validityStartHeight - The validityStartHeight for the transaction.
+     * @param {number} value - Number of Satoshis to send
+     * @param {number} fee Number of Satoshis to donate to the Miner
+     * @param {number} validityStartHeight - The validityStartHeight for the transaction
      * @param {string} [message] - Text to add to the transaction
-     * @returns {Nimiq.ExtendedTransaction} A prepared and signed Transaction object. This still has to be sent to the network.
+     * @returns {Nimiq.ExtendedTransaction} A prepared and signed Transaction object (to be sent to the network)
      */
     createVestingPayoutTransaction(sender, value, fee, validityStartHeight, message) {
-        return this.createExtendedTransaction(sender, Nimiq.Account.Type.VESTING, this.publicKey.toAddress(), null, value, fee, validityStartHeight, message);
+        return this.createExtendedTransaction(
+            sender, Nimiq.Account.Type.VESTING,
+            this.publicKey.toAddress(), null,
+            value, fee, validityStartHeight, message,
+        );
     }
 
     /**
@@ -148,9 +161,13 @@ class Key {
      * @param {number} validityStartHeight - The validityStartHeight for the transaction
      * @param {Uint8Array | string} [extraData] - Data or utf-8 text to add to the transaction
      * @param {boolean} [isContractCreation]
-     * @returns {Nimiq.ExtendedTransaction} A prepared and signed Transaction object. This still has to be sent to the network.
+     * @returns {Nimiq.ExtendedTransaction} A prepared and signed Transaction object (to be sent to the network)
      */
-    createExtendedTransaction(sender, senderType, recipient, recipientType, value, fee, validityStartHeight, extraData, isContractCreation) {
+    createExtendedTransaction(
+        sender, senderType,
+        recipient, recipientType,
+        value, fee, validityStartHeight, extraData, isContractCreation,
+    ) {
         if (typeof sender === 'string') {
             sender = Key.getUnfriendlyAddress(sender);
         }

--- a/src/lib/KeyStoreIndexeddb.js
+++ b/src/lib/KeyStoreIndexeddb.js
@@ -16,7 +16,8 @@ class KeyStore {
 
     constructor() {
         /** @type {IDBDatabase} */
-        this._db;
+        this._db; // eslint-disable-line no-unused-expressions
+
         this._connected = false;
     }
 
@@ -28,7 +29,7 @@ class KeyStore {
         if (this._connected && this._db) return Promise.resolve(this._db);
 
         return new Promise((resolve, reject) => {
-            const request = self.indexedDB.open(KeyStore.DB_NAME, KeyStore.DB_VERSION);
+            const request = window.indexedDB.open(KeyStore.DB_NAME, KeyStore.DB_VERSION);
 
             request.onsuccess = () => {
                 this._db = request.result;
@@ -108,7 +109,7 @@ class KeyStore {
             type: key.type,
         };
 
-        return await this._putPlain(keyEntry);
+        return this._putPlain(keyEntry);
     }
 
     /**
@@ -169,7 +170,8 @@ class KeyStore {
                 if (cursor) {
                     const key = cursor.value;
 
-                    // Because: To use Key.getPublicInfo(), we would need to create Key instances out of the key object that we receive from the DB.
+                    // Because: To use Key.getPublicInfo(), we would need to create Key
+                    // instances out of the key object that we receive from the DB.
                     const keyInfo = {
                         userFriendlyAddress: key.userFriendlyAddress,
                         type: key.type,
@@ -213,7 +215,7 @@ class KeyStore {
 
         const keys = await accountStore.dangerousListPlain();
 
-        for (const key of keys) {
+        keys.forEach(async key => {
             const keyEntry = {
                 encryptedKeyPair: key.encryptedKeyPair,
                 userFriendlyAddress: key.userFriendlyAddress,
@@ -221,7 +223,7 @@ class KeyStore {
                 type: /** @type {EncryptionType} */ (key.type === 'high' ? EncryptionType.HIGH : EncryptionType.LOW),
             };
             await this.putPlain(keyEntry);
-        }
+        });
 
         // FIXME Uncomment after/for testing
         // await accountStore.drop();

--- a/src/lib/KeyStoreIndexeddb.js
+++ b/src/lib/KeyStoreIndexeddb.js
@@ -6,9 +6,7 @@
  * const keyStore = KeyStore.instance;
  * const accounts = await keyStore.list();
  */
-/// <reference path="EncryptionType.js" />
 class KeyStore {
-
     /** @returns {KeyStore} */
     static get instance() {
         /** @type {KeyStore} */
@@ -105,9 +103,9 @@ class KeyStore {
         const encryptedKeyPair = await key.exportEncrypted(passphrase, unlockKey);
 
         const keyEntry = {
-            encryptedKeyPair: encryptedKeyPair,
+            encryptedKeyPair,
             userFriendlyAddress: key.userFriendlyAddress,
-            type: key.type
+            type: key.type,
         };
 
         return await this._putPlain(keyEntry);
@@ -174,7 +172,7 @@ class KeyStore {
                     // Because: To use Key.getPublicInfo(), we would need to create Key instances out of the key object that we receive from the DB.
                     const keyInfo = {
                         userFriendlyAddress: key.userFriendlyAddress,
-                        type: key.type
+                        type: key.type,
                     };
 
                     results.push(keyInfo);
@@ -220,7 +218,7 @@ class KeyStore {
                 encryptedKeyPair: key.encryptedKeyPair,
                 userFriendlyAddress: key.userFriendlyAddress,
                 // Translate between old text type and new number type
-                type: /** @type {EncryptionType} */ (key.type === 'high' ? EncryptionType.HIGH : EncryptionType.LOW)
+                type: /** @type {EncryptionType} */ (key.type === 'high' ? EncryptionType.HIGH : EncryptionType.LOW),
             };
             await this.putPlain(keyEntry);
         }

--- a/src/lib/KeyStoreIndexeddb.js
+++ b/src/lib/KeyStoreIndexeddb.js
@@ -15,9 +15,6 @@ class KeyStore {
     }
 
     constructor() {
-        /** @type {IDBDatabase} */
-        this._db; // eslint-disable-line no-unused-expressions
-
         this._connected = false;
     }
 
@@ -32,6 +29,7 @@ class KeyStore {
             const request = window.indexedDB.open(KeyStore.DB_NAME, KeyStore.DB_VERSION);
 
             request.onsuccess = () => {
+                /** @type {IDBDatabase} */
                 this._db = request.result;
                 this._connected = true;
                 resolve(this._db);

--- a/src/lib/RpcServer.js
+++ b/src/lib/RpcServer.js
@@ -11,7 +11,7 @@
  * @template T
  * @typedef { {new(...args: any[]): T }} Newable */
 
-class RpcServer {
+class RpcServer { // eslint-disable-line no-unused-vars
     /**
      * @param {object} clazz - The class whose methods will be made available via postMessage RPC
      * @param {string} allowedOrigin - The origin that is allowed to call this server
@@ -49,7 +49,11 @@ class RpcServer {
              * @param {any} result
              */
             _replyTo(message, status, result) {
-                message.source && message.source.postMessage({ status, result, id: message.data.id }, message.origin);
+                return message.source && message.source.postMessage({
+                    status,
+                    result,
+                    id: message.data.id,
+                }, message.origin);
             }
 
             /**
@@ -58,7 +62,9 @@ class RpcServer {
             _receive(message) {
                 try {
                     // FIXME Remove '*' option for release
-                    if (this._allowedOrigin !== '*' && message.origin !== this._allowedOrigin) throw new Error('Unauthorized');
+                    if (this._allowedOrigin !== '*' && message.origin !== this._allowedOrigin) {
+                        throw new Error('Unauthorized');
+                    }
 
                     const args = message.data.args && Array.isArray(message.data.args) ? message.data.args : [];
 
@@ -99,7 +105,9 @@ class RpcServer {
              */
             _error(message, error) {
                 this._replyTo(message, 'error',
-                    error.message ? { message: error.message, stack: error.stack, code: error.code } : { message: error });
+                    error.message
+                        ? { message: error.message, stack: error.stack, code: error.code }
+                        : { message: error });
             }
 
             /**
@@ -107,11 +115,11 @@ class RpcServer {
              * @param {any[]} args
              */
             _invoke(command, args) {
-                return this[command].apply(this, args);
+                return this[command](...args);
             }
         };
 
-        Server.prototype.ping = function () { return 'pong'; };
+        Server.prototype.ping = function ping() { return 'pong'; };
 
         return Server;
     }

--- a/src/lib/RpcServer.js
+++ b/src/lib/RpcServer.js
@@ -60,7 +60,7 @@ class RpcServer {
                     // FIXME Remove '*' option for release
                     if (this._allowedOrigin !== '*' && message.origin !== this._allowedOrigin) throw new Error('Unauthorized');
 
-                    let args = message.data.args && Array.isArray(message.data.args) ? message.data.args : [];
+                    const args = message.data.args && Array.isArray(message.data.args) ? message.data.args : [];
 
                     // Test if request calls an existing/whitelisted method with the right number of arguments
                     const requestedMethod = this[message.data.command];
@@ -75,7 +75,7 @@ class RpcServer {
 
                     if (result instanceof Promise) {
                         result
-                            .then((finalResult) => this._ok(message, finalResult))
+                            .then(finalResult => this._ok(message, finalResult))
                             .catch(error => this._error(message, error));
                     } else {
                         this._ok(message, result);
@@ -99,7 +99,7 @@ class RpcServer {
              */
             _error(message, error) {
                 this._replyTo(message, 'error',
-                    error.message ? { message: error.message, stack: error.stack, code: error.code } : { message: error } )
+                    error.message ? { message: error.message, stack: error.stack, code: error.code } : { message: error });
             }
 
             /**
@@ -111,7 +111,7 @@ class RpcServer {
             }
         };
 
-        Server.prototype['ping'] = function() { return 'pong'; };
+        Server.prototype.ping = function () { return 'pong'; };
 
         return Server;
     }

--- a/src/lib/TransactionType.js
+++ b/src/lib/TransactionType.js
@@ -3,5 +3,5 @@
 
 const TransactionType = {
     BASIC: 'basic',
-    EXTENDED: 'extended'
+    EXTENDED: 'extended',
 };

--- a/src/lib/TransactionType.js
+++ b/src/lib/TransactionType.js
@@ -1,7 +1,7 @@
 /** @typedef {'basic'} TransactionType.BASIC */
 /** @typedef {'extended'} TransactionType.EXTENDED */
 
-const TransactionType = {
+const TransactionType = { // eslint-disable-line no-unused-vars
     BASIC: 'basic',
     EXTENDED: 'extended',
 };

--- a/src/lib/Utf8Tools.js
+++ b/src/lib/Utf8Tools.js
@@ -1,8 +1,8 @@
+/* eslint-disable */
 /**
  * Functions taken from https://github.com/google/closure-library/blob/master/closure/goog/crypt/crypt.js
  */
 class Utf8Tools {
-
     /**
      * @param {string} str
      * @returns {Uint8Array}

--- a/src/request/PopupApi.js
+++ b/src/request/PopupApi.js
@@ -56,9 +56,10 @@ class PopupApi { // eslint-disable-line no-unused-vars
     }
 
     /**
-     * Overloaded by each pages' API class
+     * Overwritten by each request's API class
      *
      * @param {any} request
+     * @abstract
      */
     onRequest(request) { // eslint-disable-line no-unused-vars
         throw new Error('Not implemented');

--- a/src/request/PopupApi.js
+++ b/src/request/PopupApi.js
@@ -23,13 +23,13 @@
  *  runKeyguard(SignTransactionApi);
  * ```
  */
-class PopupApi {
+class PopupApi { // eslint-disable-line no-unused-vars
     constructor() {
         /** @type {Function} */
-        this._resolve;
+        this._resolve = () => {};
 
         /** @type {Function} */
-        this._reject;
+        this._reject = () => {};
     }
 
     /**
@@ -60,7 +60,7 @@ class PopupApi {
      *
      * @param {any} request
      */
-    onRequest(request) {
+    onRequest(request) { // eslint-disable-line no-unused-vars
         throw new Error('Not implemented');
     }
 

--- a/src/request/PopupApi.js
+++ b/src/request/PopupApi.js
@@ -26,10 +26,10 @@
 class PopupApi { // eslint-disable-line no-unused-vars
     constructor() {
         /** @type {Function} */
-        this._resolve = () => {};
+        this._resolve = () => { throw new Error('Method not defined'); };
 
         /** @type {Function} */
-        this._reject = () => {};
+        this._reject = () => { throw new Error('Method not defined'); };
     }
 
     /**

--- a/src/request/PopupApi.js
+++ b/src/request/PopupApi.js
@@ -24,7 +24,6 @@
  * ```
  */
 class PopupApi {
-
     constructor() {
         /** @type {Function} */
         this._resolve;
@@ -94,6 +93,6 @@ class PopupApi {
      */
     _hasMigrateFlag() {
         const match = document.cookie.match(new RegExp('migrate=([^;]+)'));
-        return match && match[1] === "1";
+        return match && match[1] === '1';
     }
 }

--- a/src/request/iframe/IFrameApi.js
+++ b/src/request/iframe/IFrameApi.js
@@ -1,10 +1,8 @@
 class IFrameApi {
-
     /**
      * @param {boolean} [listFromAccountStore] - @deprecated Only for database migration
      */
     async list(listFromAccountStore) {
-
         if (BrowserDetection.isIos() || BrowserDetection.isSafari()) {
             return CookieJar.eat(listFromAccountStore);
         }
@@ -41,6 +39,6 @@ runKeyguard(IFrameApi, {
     loadNimiq: false,
     whitelist: [
         'list',
-        'migrateAccountsToKeys'
-    ]
+        'migrateAccountsToKeys',
+    ],
 });

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -3,7 +3,6 @@ class SignTransactionApi extends PopupApi {
      * @param {TransactionRequest} txRequest
      */
     async onRequest(txRequest) {
-
         if (Nimiq.Policy.coinsToSatoshis(txRequest.value) < 1) {
             throw new AmountTooSmallError();
         }

--- a/src/request/sign-transaction/SignTransactionView.js
+++ b/src/request/sign-transaction/SignTransactionView.js
@@ -1,4 +1,4 @@
-class SignTransactionView extends Nimiq.Observable {
+class SignTransactionView extends Nimiq.Observable { // eslint-disable-line no-unused-vars
     /**
      * Decrypt key and use it to sign a transaction constructed with the data from txRequest.
      *
@@ -12,7 +12,9 @@ class SignTransactionView extends Nimiq.Observable {
             throw new Error('Not yet implemented');
         }
 
-        const { value, fee, recipient, signer, validityStartHeight } = txRequest;
+        const {
+            value, fee, recipient, signer, validityStartHeight,
+        } = txRequest;
 
         const key = await KeyStore.instance.get(signer, passphraseOrPin);
         const tx = key.createTransaction(recipient, value, fee, validityStartHeight);
@@ -28,7 +30,7 @@ class SignTransactionView extends Nimiq.Observable {
             validityStartHeight: tx.validityStartHeight,
             signature: signatureProof.signature.serialize(),
             extraData: Utf8Tools.utf8ByteArrayToString(tx.data),
-            hash: tx.hash().toBase64()
+            hash: tx.hash().toBase64(),
         };
     }
 }

--- a/src/request/sign-transaction/SignTransactionView.js
+++ b/src/request/sign-transaction/SignTransactionView.js
@@ -12,9 +12,8 @@ class SignTransactionView extends Nimiq.Observable { // eslint-disable-line no-u
             throw new Error('Not yet implemented');
         }
 
-        const {
-            value, fee, recipient, signer, validityStartHeight,
-        } = txRequest;
+        // eslint-disable-next-line object-curly-newline
+        const { value, fee, recipient, signer, validityStartHeight } = txRequest;
 
         const key = await KeyStore.instance.get(signer, passphraseOrPin);
         const tx = key.createTransaction(recipient, value, fee, validityStartHeight);

--- a/src/request/sign-transaction/SignTransactionViewWithPassphrase.js
+++ b/src/request/sign-transaction/SignTransactionViewWithPassphrase.js
@@ -35,7 +35,7 @@ class SignTransactionWithPassphrase extends SignTransactionView {
             const signedTx = await this._signTx(this._txRequest, passphrase);
             this.fire('result', signedTx);
         } catch (e) {
-            console.error(e); // eslint-disable-line no-console
+            console.error(e);
 
             document.body.classList.remove('loading');
 

--- a/src/request/sign-transaction/SignTransactionViewWithPassphrase.js
+++ b/src/request/sign-transaction/SignTransactionViewWithPassphrase.js
@@ -2,7 +2,6 @@
  *  Calls this.fire('result', [result]) when done or this.fire('error', [error]) to return with an error.
  */
 class SignTransactionWithPassphrase extends SignTransactionView {
-
     /**
      * @param {TransactionRequest} txRequest
      */
@@ -23,7 +22,7 @@ class SignTransactionWithPassphrase extends SignTransactionView {
 
         this._passphraseInput.on(PassphraseInput.Events.PASSPHRASE_ENTERED, this._handlePassphraseInput.bind(this));
 
-        location.hash = SignTransactionWithPassphrase.Pages.ENTER_PASSPHRASE;
+        window.location.hash = SignTransactionWithPassphrase.Pages.ENTER_PASSPHRASE;
     }
 
     /** @param {string} passphrase */
@@ -36,7 +35,7 @@ class SignTransactionWithPassphrase extends SignTransactionView {
             const signedTx = await this._signTx(this._txRequest, passphrase);
             this.fire('result', signedTx);
         } catch (e) {
-            console.error(e);
+            console.error(e); // eslint-disable-line no-console
 
             document.body.classList.remove('loading');
 
@@ -49,5 +48,5 @@ class SignTransactionWithPassphrase extends SignTransactionView {
 }
 
 SignTransactionWithPassphrase.Pages = {
-    ENTER_PASSPHRASE: 'enter-passphrase'
+    ENTER_PASSPHRASE: 'enter-passphrase',
 };

--- a/src/request/sign-transaction/SignTransactionViewWithPin.js
+++ b/src/request/sign-transaction/SignTransactionViewWithPin.js
@@ -2,7 +2,6 @@
  *  Calls this.fire('result', [result]) when done or this.fire('error', [error]) to return with an error.
  */
 class SignTransactionWithPin extends SignTransactionView {
-
     /**
      * @param {TransactionRequest} txRequest
      */
@@ -15,7 +14,9 @@ class SignTransactionWithPin extends SignTransactionView {
         this.$button = /** @type {HTMLElement} */ (this.$rootElement.querySelector('#transaction-data button'));
         this.$enterPin = /** @type {HTMLElement} */ (this.$rootElement.querySelector('#enter-pin'));
 
-        this.$button.addEventListener('click', () => location.hash = SignTransactionWithPin.Pages.ENTER_PIN);
+        this.$button.addEventListener('click', () => {
+            window.location.hash = SignTransactionWithPin.Pages.ENTER_PIN;
+        });
 
         this._pinInput = new PinInput();
 
@@ -26,7 +27,7 @@ class SignTransactionWithPin extends SignTransactionView {
         this._pinInput.on(PinInput.Events.PIN_ENTERED, this.handlePinInput.bind(this));
 
         // go to start page
-        location.hash = SignTransactionWithPin.Pages.TRANSACTION_DATA;
+        window.location.hash = SignTransactionWithPin.Pages.TRANSACTION_DATA;
     }
 
     /** @param {string} pin */
@@ -38,7 +39,7 @@ class SignTransactionWithPin extends SignTransactionView {
             this._pinInput.close();
             this.fire('result', signedTx);
         } catch (e) {
-            console.error(e);
+            console.error(e); // eslint-disable-line no-console
 
             document.body.classList.remove('loading');
 
@@ -50,5 +51,5 @@ class SignTransactionWithPin extends SignTransactionView {
 
 SignTransactionWithPin.Pages = {
     TRANSACTION_DATA: 'transaction-data',
-    ENTER_PIN: 'enter-pin'
+    ENTER_PIN: 'enter-pin',
 };

--- a/src/request/sign-transaction/SignTransactionViewWithPin.js
+++ b/src/request/sign-transaction/SignTransactionViewWithPin.js
@@ -39,7 +39,7 @@ class SignTransactionWithPin extends SignTransactionView {
             this._pinInput.close();
             this.fire('result', signedTx);
         } catch (e) {
-            console.error(e); // eslint-disable-line no-console
+            console.error(e);
 
             document.body.classList.remove('loading');
 

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -1,21 +1,21 @@
 const TRANSLATIONS = {
-    "en": {
-        _language: "English",
-        "loading": "Loading...",
-        "passphrase-strength": "Strength",
-        "passphrase-confirm": "Confirm",
-        "passphrase-placeholder": "Enter passphrase",
-        "sign-tx-wrong-passphrase": "Wrong passphrase, please try again",
-        "sign-tx-button-enter-pin": "Enter PIN",
+    en: {
+        _language: 'English',
+        loading: 'Loading...',
+        'passphrase-strength': 'Strength',
+        'passphrase-confirm': 'Confirm',
+        'passphrase-placeholder': 'Enter passphrase',
+        'sign-tx-wrong-passphrase': 'Wrong passphrase, please try again',
+        'sign-tx-button-enter-pin': 'Enter PIN',
     },
-    "de": {
-        _language: "Deutsch",
-        "loading": "Wird geladen...",
-        "passphrase-strength": "Stärke",
-        "passphrase-confirm": "Bestätigen",
-        "passphrase-placeholder": "Passphrase eingeben",
-        "sign-tx-wrong-passphrase": "Falsche Passphrase, bitte versuche es nochmal",
-        "sign-tx-button-enter-pin": "PIN eingeben",
+    de: {
+        _language: 'Deutsch',
+        loading: 'Wird geladen...',
+        'passphrase-strength': 'Stärke',
+        'passphrase-confirm': 'Bestätigen',
+        'passphrase-placeholder': 'Passphrase eingeben',
+        'sign-tx-wrong-passphrase': 'Falsche Passphrase, bitte versuche es nochmal',
+        'sign-tx-button-enter-pin': 'PIN eingeben',
     },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,16 @@ accepts@~1.3.4:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
+  dependencies:
+    acorn "^5.0.3"
+
+acorn@^5.0.3, acorn@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
 addressparser@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-1.0.1.tgz#47afbe1a2a9262191db6838e4fd1d39b40821746"
@@ -31,6 +41,10 @@ agent-base@4, agent-base@^4.1.0, agent-base@^4.2.0:
   dependencies:
     es6-promisify "^5.0.0"
 
+ajv-keywords@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
+
 ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -39,6 +53,15 @@ ajv@^5.1.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.0.1, ajv@^6.5.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.1"
 
 amqplib@^0.5.2:
   version "0.5.2"
@@ -49,6 +72,10 @@ amqplib@^0.5.2:
     buffer-more-ints "0.0.2"
     readable-stream "1.x >=1.1.9"
     safe-buffer "^5.0.1"
+
+ansi-escapes@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -61,6 +88,12 @@ ansi-regex@^3.0.0:
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -80,6 +113,12 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -96,6 +135,16 @@ array-slice@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
 
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -107,6 +156,10 @@ array-unique@^0.3.2:
 arraybuffer.slice@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
+
+arrify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
 asn1@~0.2.3:
   version "0.2.3"
@@ -167,6 +220,14 @@ axios@^0.15.3:
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
   dependencies:
     follow-redirects "1.0.0"
+
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -297,6 +358,10 @@ buildmail@4.0.1:
     nodemailer-shared "1.1.0"
     punycode "1.4.1"
 
+builtin-modules@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -315,9 +380,19 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
 callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -327,7 +402,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chalk@^1.1.1:
+chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -336,6 +411,18 @@ chalk@^1.1.1:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.0.0, chalk@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 chokidar@^2.0.3:
   version "2.0.4"
@@ -360,6 +447,10 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
+circular-json@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
 circular-json@^0.5.4:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.5.tgz#64182ef359042d37cd8e767fc9de878b1e9447d3"
@@ -372,6 +463,16 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
 co@^4.6.0:
   version "4.6.0"
@@ -387,6 +488,16 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  dependencies:
+    color-name "1.1.1"
+
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
 colors@^1.1.0:
   version "1.3.0"
@@ -437,6 +548,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -456,6 +571,16 @@ core-js@^2.2.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -481,7 +606,7 @@ date-format@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-1.2.0.tgz#615e828e233dd1ab9bb9ae0950e0ceccfa6ecad8"
 
-debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@~2.6.4, debug@~2.6.6:
+debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -504,6 +629,13 @@ deep-extend@^0.6.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -532,6 +664,18 @@ degenerator@^1.0.4:
     escodegen "1.x.x"
     esprima "3.x.x"
 
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -551,6 +695,19 @@ detect-libc@^1.0.2:
 di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -622,6 +779,30 @@ ent@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
 
+error-ex@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  dependencies:
+    is-arrayish "^0.2.1"
+
+es-abstract@^1.10.0, es-abstract@^1.6.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
 es6-promise@^4.0.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
@@ -636,7 +817,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.2:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -651,11 +832,129 @@ escodegen@1.x.x:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-airbnb-base@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.0.0.tgz#2ee6279c4891128e49d6445b24aa13c2d1a21450"
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz#df24f241175e312d91662dc91ca84064caec14ed"
+  dependencies:
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.2.0"
+    has "^1.0.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+    resolve "^1.6.0"
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.0.1.tgz#109b90ab7f7a736f54e0f341c8bb9d09777494c3"
+  dependencies:
+    ajv "^6.5.0"
+    babel-code-frame "^6.26.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.5.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^5.2.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.11.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.1.0"
+    require-uncached "^1.0.3"
+    semver "^5.5.0"
+    string.prototype.matchall "^2.0.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
+
+espree@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
+  dependencies:
+    acorn "^5.6.0"
+    acorn-jsx "^4.1.1"
+
 esprima@3.x.x, esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-estraverse@^4.2.0:
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -711,6 +1010,14 @@ extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+external-editor@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -736,6 +1043,10 @@ fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -743,6 +1054,19 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 file-uri-to-path@1:
   version "1.0.0"
@@ -769,6 +1093,28 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
+
+flat-cache@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
+
 follow-redirects@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
@@ -784,6 +1130,10 @@ follow-redirects@^1.0.0:
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -841,6 +1191,14 @@ ftp@~0.3.10:
     readable-stream "1.1.x"
     xregexp "2.0.0"
 
+function-bind@^1.1.0, function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -892,7 +1250,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -902,6 +1260,21 @@ glob@^7.0.5, glob@^7.1.1:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+globals@^11.5.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 graceful-fs@^4.1.2:
   version "4.1.11"
@@ -943,6 +1316,14 @@ has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -974,6 +1355,12 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+has@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -993,6 +1380,10 @@ hipchat-notifier@^1.1.0:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+hosted-git-info@^2.1.4:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.1.tgz#6e4cee78b01bb849dcf93527708c69fdbee410df"
 
 http-errors@1.6.3, http-errors@~1.6.3:
   version "1.6.3"
@@ -1056,7 +1447,7 @@ iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
-iconv-lite@0.4.23, iconv-lite@^0.4.4:
+iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -1067,6 +1458,14 @@ ignore-walk@^3.0.1:
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
   dependencies:
     minimatch "^3.0.4"
+
+ignore@^3.3.3:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
 indexof@0.0.1:
   version "0.0.1"
@@ -1095,6 +1494,24 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
+inquirer@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
 ip@^1.1.2, ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -1111,6 +1528,10 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -1120,6 +1541,16 @@ is-binary-path@^1.0.0:
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
+
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -1132,6 +1563,10 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -1209,19 +1644,53 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
     isobject "^3.0.1"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
+is-resolvable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1235,7 +1704,7 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -1269,6 +1738,17 @@ jasmine-core@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.1.0.tgz#a4785e135d5df65024dfc9224953df585bd2766c"
 
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+js-yaml@^3.11.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -1277,9 +1757,17 @@ json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stringify-safe@5.0.x, json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -1361,7 +1849,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -1384,11 +1872,27 @@ libqp@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/libqp/-/libqp-1.1.0.tgz#f5e6e06ad74b794fb5b5b66988bf728ef1dedbe8"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -1497,7 +2001,11 @@ mime@^1.3.4:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1545,6 +2053,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
 nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -1565,6 +2077,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
 needle@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
@@ -1580,6 +2096,10 @@ negotiator@0.6.1:
 netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
+
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
 
 node-pre-gyp@^0.10.0:
   version "0.10.2"
@@ -1656,6 +2176,15 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+normalize-package-data@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -1694,7 +2223,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1710,11 +2239,33 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.11, object-keys@^1.0.8:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -1734,6 +2285,12 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -1741,7 +2298,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -1767,6 +2324,22 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  dependencies:
+    p-try "^1.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
 pac-proxy-agent@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz#90d9f6730ab0f4d2607dcdcd4d3d641aa26c3896"
@@ -1789,6 +2362,12 @@ pac-resolver@^3.0.0:
     ip "^1.1.5"
     netmask "^1.0.6"
     thunkify "^2.1.2"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
 
 parseqs@0.0.5:
   version "0.0.5"
@@ -1814,9 +2393,31 @@ path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
 path-proxy@~1.0.0:
   version "1.0.0"
@@ -1824,9 +2425,19 @@ path-proxy@~1.0.0:
   dependencies:
     inflection "~1.3.0"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
+pify@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -1837,6 +2448,16 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -1853,6 +2474,10 @@ process-nextick-args@~1.0.6:
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 promisify-call@^2.0.2:
   version "2.0.4"
@@ -1884,6 +2509,10 @@ pseudomap@^1.0.2:
 punycode@1.4.1, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qjobs@^1.1.4:
   version "1.2.0"
@@ -1918,6 +2547,21 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 readable-stream@1.1.x, "readable-stream@1.x >=1.1.9":
   version "1.1.14"
@@ -1982,6 +2626,16 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp.prototype.flags@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
+  dependencies:
+    define-properties "^1.1.2"
+
+regexpp@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -2059,23 +2713,59 @@ requestretry@^1.2.2:
     request "^2.74.0"
     when "^3.7.7"
 
+require-uncached@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
+resolve@^1.5.0, resolve@^1.6.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  dependencies:
+    path-parse "^1.0.5"
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rimraf@^2.6.0, rimraf@^2.6.1:
+rimraf@^2.2.8, rimraf@^2.6.0, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
+
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
+rxjs@^5.5.2:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -2095,7 +2785,7 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-semver@^5.3.0, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -2129,7 +2819,17 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
-signal-exit@^3.0.0:
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -2138,6 +2838,12 @@ slack-node@~0.2.0:
   resolved "https://registry.yarnpkg.com/slack-node/-/slack-node-0.2.0.tgz#de4b8dddaa8b793f61dbd2938104fdabf37dfa30"
   dependencies:
     requestretry "^1.2.2"
+
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 smart-buffer@^1.0.13, smart-buffer@^1.0.4:
   version "1.1.15"
@@ -2267,11 +2973,37 @@ source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
   version "1.14.2"
@@ -2320,12 +3052,22 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2":
+"string-width@^1.0.2 || 2", string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string.prototype.matchall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz#2af8fe3d2d6dc53ca2a59bd376b089c3c152b3c8"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    regexp.prototype.flags "^1.2.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -2353,13 +3095,38 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-json-comments@~2.0.1:
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
+table@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
+  dependencies:
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 tar@^4:
   version "4.4.4"
@@ -2373,6 +3140,14 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
 thunkify@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
@@ -2381,7 +3156,7 @@ timespan@2.3.x:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/timespan/-/timespan-2.3.0.tgz#4902ce040bd13d845c8f59b27e9d59bad6f39929"
 
-tmp@0.0.33, tmp@0.0.x:
+tmp@0.0.33, tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:
@@ -2486,6 +3261,12 @@ upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
+uri-js@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  dependencies:
+    punycode "^2.1.0"
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -2519,6 +3300,13 @@ uws@~9.14.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/uws/-/uws-9.14.0.tgz#fac8386befc33a7a3705cbd58dc47b430ca4dd95"
 
+validate-npm-package-license@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -2535,7 +3323,7 @@ when@^3.7.7:
   version "3.7.8"
   resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
 
-which@^1.2.1:
+which@^1.2.1, which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
@@ -2562,6 +3350,12 @@ wordwrap@~1.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@~3.3.1:
   version "3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,8 +1382,8 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hosted-git-info@^2.1.4:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.1.tgz#6e4cee78b01bb849dcf93527708c69fdbee410df"
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
 http-errors@1.6.3, http-errors@~1.6.3:
   version "1.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,7 +412,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -572,6 +572,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -721,6 +729,10 @@ dom-serialize@^2.2.0:
 double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+
+duplexer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -962,6 +974,18 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+event-stream@~3.3.0:
+  version "3.3.4"
+  resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -1160,6 +1184,10 @@ fragment-cache@^0.2.1:
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
   dependencies:
     map-cache "^0.2.2"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
 fs-access@^1.0.0:
   version "1.0.1"
@@ -1927,7 +1955,7 @@ lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 
-lru-cache@^4.1.2:
+lru-cache@^4.0.1, lru-cache@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
@@ -1958,6 +1986,10 @@ mailgun-js@^0.18.0:
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -2431,6 +2463,12 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -2501,6 +2539,12 @@ proxy-agent@~3.0.0:
 proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
+ps-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
+  dependencies:
+    event-stream "~3.3.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -3001,6 +3045,12 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -3034,6 +3084,12 @@ static-extend@^0.1.1:
 statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  dependencies:
+    duplexer "~0.1.1"
 
 streamroller@0.7.0:
   version "0.7.0"
@@ -3144,7 +3200,7 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-through@^2.3.6:
+through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -3194,6 +3250,16 @@ tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+tsc-watch@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/tsc-watch/-/tsc-watch-1.0.22.tgz#e11eea984bd0c90c4b7bfac557c9e66b2e7899da"
+  dependencies:
+    chalk "^2.3.0"
+    cross-spawn "^5.1.0"
+    ps-tree "^1.1.0"
+    strip-ansi "^4.0.0"
+    typescript "*"
+
 tsscmp@~1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.5.tgz#7dc4a33af71581ab4337da91d85ca5427ebd9a97"
@@ -3225,7 +3291,7 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@^2.9.2:
+typescript@*, typescript@^2.9.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 


### PR DESCRIPTION
Apply the _industry standard_ `airbnb-base` ESLint config (with some adaptions, see `rules` in `.eslintrc.json` file) and fix all errors in `src/`. Also configures the linter to run in Travis for pull requests.

Use `npm run lint`/`yarn lint` to see errors and `npm run lintfix`/`yarn lintfix` to automatically fix basic things like spacing, commas, indentation and quotes.

Use `npm run pr`/`yarn pr` to run all three checks (`typecheck`, `lint`, `test`) as they would for a PR.