### PR TITLE
Implement message signing on Key

### DIFF
--- a/Keyguard.d.ts
+++ b/Keyguard.d.ts
@@ -49,6 +49,11 @@ type ExtendedTransactionRequest = BasicTransactionRequest & {
 
 type TransactionRequest = BasicTransactionRequest | ExtendedTransactionRequest
 
+type SignedMessageResult = {
+    message: string | Uint8Array
+    proof: Nimiq.SignatureProof
+}
+
 interface Window { rpcServer: RpcServer; KeyStore: any }
 
 interface Newable {

--- a/Nimiq.d.ts
+++ b/Nimiq.d.ts
@@ -41,7 +41,35 @@ declare namespace Nimiq {
         static toHex(buf: Uint8Array): string
     }
 
-    class SerialBuffer extends Uint8Array {}
+    class SerialBuffer extends Uint8Array {
+        constructor(bufferOrArrayOrLength: any)
+        subarray(start: number, end: number): Uint8Array
+        readPos: number
+        writePos: number
+        reset(): void
+        read(length: number): Uint8Array
+        write(array: any): void
+        readUint8(): number
+        writeUint8(value: number): void
+        readUint16(): number
+        writeUint16(value: number): void
+        readUint32(): number
+        writeUint32(value: number): void
+        readUint64(): number
+        writeUint64(value: number): void
+        readVarInt(): number
+        writeVarInt(value: number): void
+        static varUintSize(value: number): number
+        readFloat64(): number
+        writeFloat64(value: number): void
+        readString(length: number): string
+        writeString(value: string, length: number): void
+        readPaddedString(length: number): string
+        writePaddedString(value: string, length: number): void
+        readVarLengthString(): string
+        writeVarLengthString(value: string): void
+        static varLengthStringSize(value: string): number
+    }
 
     class Synchronizer {}
     class MultiSynchronizer {}
@@ -222,7 +250,7 @@ declare namespace Nimiq {
         static verifyTransaction(transaction: Transaction): boolean
         static singleSig(publicKey: PublicKey, signature: Signature): SignatureProof
         static multiSig(signerKey: PublicKey, publicKeys: PublicKey[], signature: Signature): SignatureProof
-        static unserialize(buf: SerialBuffer): SignatureProof
+        static unserialize(buf: Uint8Array): SignatureProof
         serialize(): SerialBuffer
         verify(address: Address | null, data: Uint8Array): boolean
         publicKey: PublicKey

--- a/src/lib/Key.js
+++ b/src/lib/Key.js
@@ -79,7 +79,7 @@ class Key { // eslint-disable-line no-unused-vars
      * Sign a generic message.
      *
      * @param {string | Uint8Array} message - A utf-8 string or byte array (max 255 bytes)
-     * @returns {{message: string | Uint8Array, proof: Nimiq.SignatureProof}}
+     * @returns {SignedMessageResult}
      */
     signMessage(message) {
         /**

--- a/src/lib/Key.js
+++ b/src/lib/Key.js
@@ -78,14 +78,48 @@ class Key { // eslint-disable-line no-unused-vars
     /**
      * Sign a generic message.
      *
-     * @param {string} message - A utf-8 string
-     * @returns {{message: string, signature: Nimiq.Signature}}
+     * @param {string | Uint8Array} message - A utf-8 string or byte array (max 255 bytes)
+     * @returns {{message: string | Uint8Array, proof: Nimiq.SignatureProof}}
      */
     signMessage(message) {
-        message = `nimiq_msg_${message}`;
-        const msgBytes = Utf8Tools.stringToUtf8ByteArray(message);
-        const signature = Nimiq.Signature.create(this.keyPair.privateKey, this.keyPair.publicKey, msgBytes);
-        return { message, signature };
+        /**
+         * Adding a prefix to the message makes the calculated signature recognisable as
+         * a Nimiq specific signature. This prevents misuse where a malicious request can
+         * sign arbitrary data (e.g. a transaction) and use the signature to impersonate
+         * the victim. (https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign)
+         */
+        const prefix = 'Nimiq Signed Message:\n';
+        const prefixBytes = new Nimiq.SerialBuffer(Utf8Tools.stringToUtf8ByteArray(prefix));
+        const prefixLength = prefixBytes.length;
+
+        /** @type {Nimiq.SerialBuffer} */
+        let msgBytes;
+        if (typeof message === 'string') {
+            msgBytes = new Nimiq.SerialBuffer(Utf8Tools.stringToUtf8ByteArray(message));
+        } else {
+            msgBytes = new Nimiq.SerialBuffer(message);
+        }
+
+        const msgLength = msgBytes.length;
+
+        if (msgLength > 255) {
+            throw new Error('Message must not exceed 255 bytes');
+        }
+
+        const bufLength = 1 /* prefixBytes length value */
+            + prefixLength
+            + 1 /* msgBytes length value */
+            + msgLength;
+
+        // Construct buffer
+        const buf = new Nimiq.SerialBuffer(bufLength);
+        buf.writeUint8(prefixLength);
+        buf.write(prefixBytes);
+        buf.writeUint8(msgLength);
+        buf.write(msgBytes);
+
+        const proof = this._makeSignatureProof(buf);
+        return { message, proof };
     }
 
     /**


### PR DESCRIPTION
This PR improves the `signMessage()` function on the Key class. It does not yet implement the request type.