### PR TITLE
Soeren/improve iqons

### DIFF
--- a/demos/Identicon.html
+++ b/demos/Identicon.html
@@ -16,6 +16,8 @@
 <script src="../src/lib/Iqons.js"></script>
 <script src="../src/components/Identicon.js"></script>
 <script>
+    Iqons.svgPath = '../src/lib/Iqons.min.svg';
+
     console.warn("This demo needs to be executed as localhost from the nimiq.github.io directory.");
 
     let count = 0;

--- a/src/components/Identicon.js
+++ b/src/components/Identicon.js
@@ -49,6 +49,7 @@ class Identicon { // eslint-disable-line no-unused-vars
 
         if (this._address) {
             Iqons.toDataUrl(this._address).then(url => {
+                // Placeholder setting above is synchronous, thus this async result will replace the placeholder
                 /** @type {HTMLImageElement} */ (this.$imgEl).src = url;
             });
         }

--- a/src/components/Identicon.js
+++ b/src/components/Identicon.js
@@ -43,12 +43,14 @@ class Identicon { // eslint-disable-line no-unused-vars
     }
 
     _updateIqon() {
+        if (!this._address || !Iqons.hasAssets) {
+            /** @type {HTMLImageElement} */ (this.$imgEl).src = Iqons.placeholderToDataUrl();
+        }
+
         if (this._address) {
             Iqons.toDataUrl(this._address).then(url => {
                 /** @type {HTMLImageElement} */ (this.$imgEl).src = url;
             });
-        } else {
-            /** @type {HTMLImageElement} */ (this.$imgEl).src = Iqons.placeholderToDataUrl();
         }
     }
 }

--- a/src/lib/Iqons.js
+++ b/src/lib/Iqons.js
@@ -148,8 +148,8 @@ class Iqons {
      * @returns {Promise<Document>}
      */
     static async _getAssets() {
-        if (this._assets) return this._assets;
-        return fetch(this.svgPath)
+        /** @type {Promise<Document>} */
+        this._assetPromise = this._assetPromise || fetch(this.svgPath)
             .then(response => response.text())
             .then(assetsText => {
                 const parser = new DOMParser();
@@ -157,6 +157,7 @@ class Iqons {
                 this._assets = assets;
                 return assets;
             });
+        return this._assetPromise;
     }
 
     static get hasAssets() {

--- a/src/lib/Iqons.js
+++ b/src/lib/Iqons.js
@@ -159,6 +159,10 @@ class Iqons {
             });
     }
 
+    static get hasAssets() {
+        return !!this._assets;
+    }
+
     /** @type {string[]} */
     static get colors() {
         return [


### PR DESCRIPTION
Three fixes in this PR:

1. in the `Identicon.js` component: The Iqon placeholder is now displayed while the asset SVG file is loaded in the background. Important for all page views that are not `localhost` ;)

2. Previously, when more than one Iqon is initialized at the same time on page load, the asset SVG file would be loaded separately for all Iqon instances, because they did not share a common promise. This is fixed in the `Iqons.js` library here with a common `this._assetPromise`.

3. Also fixes asset path in the demo file.