### PR TITLE
Add payment-info line to SignTransaction CheckoutLayout

### DIFF
--- a/src/components/PaymentInfoLine.css
+++ b/src/components/PaymentInfoLine.css
@@ -1,0 +1,21 @@
+.payment-info-line {
+    width: 100vw;
+    max-width: 56.25rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    color: white;
+    font-size: 1.5rem;
+    line-height: 1;
+    margin-bottom: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.15rem;
+}
+
+.payment-info-line .amount {
+    font-weight: bold;
+}
+
+.payment-info-line .nim-symbol::before {
+    opacity: 1;
+}

--- a/src/components/PaymentInfoLine.js
+++ b/src/components/PaymentInfoLine.js
@@ -1,0 +1,48 @@
+/* global Nimiq */
+
+class PaymentInfoLine extends Nimiq.Observable { // eslint-disable-line no-unused-vars
+    /**
+     * @param {?HTMLElement} $el
+     * @param {string} domain
+     * @param {string} formattedAmount
+     */
+    constructor($el, domain, formattedAmount) {
+        super();
+        this.$el = PaymentInfoLine._createElement($el, domain, formattedAmount);
+        this.$el.classList.remove('display-none');
+    }
+
+    /**
+     * @param {?HTMLElement} [$el]
+     * @param {string} domain
+     * @param {string} formattedAmount
+     * @returns {HTMLElement}
+     */
+    static _createElement($el, domain, formattedAmount) {
+        $el = $el || document.createElement('div');
+        $el.classList.add('payment-info-line');
+
+        $el.innerHTML = `
+            <div class="description">
+                Payment to
+                <span origin>${domain}</span>
+            </div>
+            <div class="amount">
+                <span amount>${formattedAmount}</span>
+                <span class="nim-symbol"></span>
+            </div>
+        `;
+
+        return $el;
+    }
+
+    /** @returns {HTMLElement} @deprecated */
+    getElement() {
+        return this.$el;
+    }
+
+    /** @type {HTMLElement} */
+    get element() {
+        return this.$el;
+    }
+}

--- a/src/components/PaymentInfoLine.js
+++ b/src/components/PaymentInfoLine.js
@@ -25,13 +25,16 @@ class PaymentInfoLine extends Nimiq.Observable { // eslint-disable-line no-unuse
         $el.innerHTML = `
             <div class="description">
                 Payment to
-                <span origin>${domain}</span>
+                <span domain></span>
             </div>
             <div class="amount">
-                <span amount>${formattedAmount}</span>
+                <span amount></span>
                 <span class="nim-symbol"></span>
             </div>
         `;
+
+        /** @type {HTMLElement} */ ($el.querySelector('[domain]')).textContent = domain;
+        /** @type {HTMLElement} */ ($el.querySelector('[amount]')).textContent = formattedAmount;
 
         return $el;
     }

--- a/src/request/sign-transaction/LayoutCheckout.js
+++ b/src/request/sign-transaction/LayoutCheckout.js
@@ -1,6 +1,7 @@
 /* global BaseLayout */
 /* global I18n */
 /* global Nimiq */
+/* global PaymentInfoLine */
 
 class LayoutCheckout extends BaseLayout { // eslint-disable-line no-unused-vars
     /**
@@ -18,19 +19,17 @@ class LayoutCheckout extends BaseLayout { // eslint-disable-line no-unused-vars
         super(request, resolve, reject);
         this.$el = container;
 
-        // Fill payment-info-line
-        const $infoLine = /** @type {HTMLElement} */ (document.querySelector('.payment-info-line'));
-        const $infoLineOrigin = /** @type {HTMLElement} */ (document.getElementById('info-line-origin'));
-        const $infoLineAmount = /** @type {HTMLElement} */ (document.getElementById('info-line-amount'));
-
-        $infoLineOrigin.textContent = LayoutCheckout._originToDomain(request.shopOrigin);
+        // Set up payment-info-line
+        const $paymentInfoLine = /** @type {HTMLElement} */ (document.querySelector('.payment-info-line'));
 
         const transaction = request.transaction;
         const total = transaction.value + transaction.fee;
         const totalNim = Nimiq.Policy.satoshisToCoins(total);
-        $infoLineAmount.textContent = this._formatNumber(totalNim);
-
-        $infoLine.classList.remove('display-none');
+        new PaymentInfoLine( // eslint-disable-line no-new
+            $paymentInfoLine,
+            LayoutCheckout._originToDomain(request.shopOrigin),
+            this._formatNumber(totalNim),
+        );
     }
 
     /**

--- a/src/request/sign-transaction/LayoutCheckout.js
+++ b/src/request/sign-transaction/LayoutCheckout.js
@@ -1,5 +1,6 @@
 /* global BaseLayout */
 /* global I18n */
+/* global Nimiq */
 
 class LayoutCheckout extends BaseLayout { // eslint-disable-line no-unused-vars
     /**
@@ -9,13 +10,27 @@ class LayoutCheckout extends BaseLayout { // eslint-disable-line no-unused-vars
      * @param {Function} reject
      */
     constructor($el, request, resolve, reject) {
-        request.recipientLabel = LayoutCheckout._originToDomain(request.shopOrigin || '---');
+        request.recipientLabel = LayoutCheckout._originToDomain(request.shopOrigin);
 
         // `this` can only be accessed after `super` has been called,
         // but `super` requires the HTML to already exist.
         const container = LayoutCheckout._createElement($el);
         super(request, resolve, reject);
         this.$el = container;
+
+        // Fill payment-info-line
+        const $infoLine = /** @type {HTMLElement} */ (document.querySelector('.payment-info-line'));
+        const $infoLineOrigin = /** @type {HTMLElement} */ (document.getElementById('info-line-origin'));
+        const $infoLineAmount = /** @type {HTMLElement} */ (document.getElementById('info-line-amount'));
+
+        $infoLineOrigin.textContent = LayoutCheckout._originToDomain(request.shopOrigin);
+
+        const transaction = request.transaction;
+        const total = transaction.value + transaction.fee;
+        const totalNim = Nimiq.Policy.satoshisToCoins(total);
+        $infoLineAmount.textContent = this._formatNumber(totalNim);
+
+        $infoLine.classList.remove('display-none');
     }
 
     /**
@@ -66,10 +81,11 @@ class LayoutCheckout extends BaseLayout { // eslint-disable-line no-unused-vars
     }
 
     /**
-     * @param {string} origin
+     * @param {string} [origin]
      * @returns {string}
      */
     static _originToDomain(origin) {
+        if (!origin) return '---';
         return origin.split('://')[1] || '---';
     }
 }

--- a/src/request/sign-transaction/SignTransaction.css
+++ b/src/request/sign-transaction/SignTransaction.css
@@ -90,6 +90,10 @@
 #######################################
 */
 
+.payment-info-line {
+    margin-top: -3rem;
+}
+
 .layout-checkout h1 {
     font-size: 3rem;
     font-weight: 300;

--- a/src/request/sign-transaction/SignTransaction.css
+++ b/src/request/sign-transaction/SignTransaction.css
@@ -90,28 +90,6 @@
 #######################################
 */
 
-.payment-info-line {
-    width: 100vw;
-    max-width: 56.25rem;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    color: white;
-    font-size: 1.5rem;
-    line-height: 1;
-    margin-bottom: 1.5rem;
-    text-transform: uppercase;
-    letter-spacing: 0.15rem;
-}
-
-.payment-info-line .amount {
-    font-weight: bold;
-}
-
-.payment-info-line .nim-symbol::before {
-    opacity: 1;
-}
-
 .layout-checkout h1 {
     font-size: 3rem;
     font-weight: 300;

--- a/src/request/sign-transaction/SignTransaction.css
+++ b/src/request/sign-transaction/SignTransaction.css
@@ -90,6 +90,28 @@
 #######################################
 */
 
+.payment-info-line {
+    width: 100vw;
+    max-width: 56.25rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    color: white;
+    font-size: 1.5rem;
+    line-height: 1;
+    margin-bottom: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.15rem;
+}
+
+.payment-info-line .amount {
+    font-weight: bold;
+}
+
+.payment-info-line .nim-symbol::before {
+    opacity: 1;
+}
+
 .layout-checkout h1 {
     font-size: 3rem;
     font-weight: 300;
@@ -154,6 +176,7 @@
     font-size: 2rem;
     line-height: 1.3;
     opacity: 0.7;
+    margin-bottom: 0;
 }
 
 .layout-checkout .sender-section {

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -47,6 +47,17 @@
     <div id="app">
         <div class="flex-grow"></div>
 
+        <div class="payment-info-line display-none">
+            <div class="description">
+                Payment to
+                <span id="info-line-origin"></span>
+            </div>
+            <div class="amount">
+                <span id="info-line-amount"></span>
+                <span class="nim-symbol"></span>
+            </div>
+        </div>
+
         <div id="confirm-transaction" class="page">
             <div id="layout-container"></div>
 

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -24,6 +24,7 @@
     <script defer src="../../components/PassphraseInput.js"></script>
     <script defer src="../../components/PassphraseBox.js"></script>
     <script defer src="../../components/Identicon.js"></script>
+    <script defer src="../../components/PaymentInfoLine.js"></script>
     <script defer src="../TopLevelApi.js"></script>
     <script defer src="BaseLayout.js"></script>
     <script defer src="LayoutStandard.js"></script>
@@ -35,6 +36,7 @@
     <link rel="stylesheet" href="../../common.css">
     <link rel="stylesheet" href="../../components/PassphraseInput.css">
     <link rel="stylesheet" href="../../components/PassphraseBox.css">
+    <link rel="stylesheet" href="../../components/PaymentInfoLine.css">
     <link rel="stylesheet" href="SignTransaction.css">
 </head>
 <body>
@@ -47,16 +49,7 @@
     <div id="app">
         <div class="flex-grow"></div>
 
-        <div class="payment-info-line display-none">
-            <div class="description">
-                Payment to
-                <span id="info-line-origin"></span>
-            </div>
-            <div class="amount">
-                <span id="info-line-amount"></span>
-                <span class="nim-symbol"></span>
-            </div>
-        </div>
+        <div class="payment-info-line display-none"></div>
 
         <div id="confirm-transaction" class="page">
             <div id="layout-container"></div>

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -49,9 +49,9 @@
     <div id="app">
         <div class="flex-grow"></div>
 
-        <div class="payment-info-line display-none"></div>
-
         <div id="confirm-transaction" class="page">
+            <div class="payment-info-line display-none"></div>
+
             <div id="layout-container"></div>
 
             <div class="page-footer">


### PR DESCRIPTION
Resolves #83.

Only problem remaining is how to hide the info-line when the user goes back or cancels the signing. The Keyguard shortly shows the loading animation again before redirecting back to the AccountsManager. In that time, the page is hidden because it is not a CSS target anymore, but the payment-info-line lives outside the page, so is not hidden. And CSS can only be written to affect later elements in the DOM, so the info-line cannot react to a page being hidden (the page comes after the info-line)...

Only possibility I see is instead of relying solely on the CSS target, to also add a `loading` class or similar to the body or `#app` element... @Bettelstab?