### PR TITLE
Enable transaction signing with unencrypted keys

### DIFF
--- a/src/components/PassphraseBox.css
+++ b/src/components/PassphraseBox.css
@@ -25,8 +25,13 @@
     transition: transform 300ms;
 }
 
-.passphrase-box.input-valid .passphrase-input {
+.passphrase-box.input-valid .passphrase-input,
+.passphrase-box.hide-input .passphrase-input {
     transform: translate3d(0, -6.5rem, 0);
+}
+
+.passphrase-box.hide-input .passphrase-input {
+    visibility: hidden;
 }
 
 .passphrase-box .submit {
@@ -36,7 +41,8 @@
     pointer-events: none;
 }
 
-.passphrase-box.input-valid .submit {
+.passphrase-box.input-valid .submit,
+.passphrase-box.hide-input .submit {
     opacity: 1;
     transition-delay: 75ms;
     pointer-events: all;
@@ -46,7 +52,8 @@
     transition: opacity 300ms;
 }
 
-.passphrase-box.input-valid .prompt {
+.passphrase-box.input-valid .prompt,
+.passphrase-box.hide-input .prompt {
     opacity: 0;
 }
 

--- a/src/components/PassphraseBox.js
+++ b/src/components/PassphraseBox.js
@@ -24,6 +24,8 @@ class PassphraseBox extends Nimiq.Observable {
         this._passphraseInput = new PassphraseInput(this.$el.querySelector('[passphrase-input]'));
         this._passphraseInput.on(PassphraseInput.Events.VALID, isValid => this._onInputChangeValidity(isValid));
 
+        this._isInputValid = false;
+
         this.$el.addEventListener('submit', event => this._onSubmit(event));
 
         /** @type {HTMLElement} */
@@ -100,6 +102,7 @@ class PassphraseBox extends Nimiq.Observable {
      * @param {boolean} isValid
      */
     _onInputChangeValidity(isValid) {
+        this._isInputValid = isValid;
         this.$el.classList.toggle('input-valid', isValid);
     }
 
@@ -108,6 +111,7 @@ class PassphraseBox extends Nimiq.Observable {
      */
     _onSubmit(event) {
         event.preventDefault();
+        if (!this.options.hideInput && !this._isInputValid) return;
         this.fire(PassphraseBox.Events.SUBMIT, this._passphraseInput.text);
     }
 

--- a/src/components/PassphraseBox.js
+++ b/src/components/PassphraseBox.js
@@ -10,7 +10,7 @@ class PassphraseBox extends Nimiq.Observable {
     constructor($el, options = {}) {
         const defaults = {
             bgColor: 'purple',
-            hideInput: false, // TODO: When a key is not encrypted, no passphrase is required
+            hideInput: false,
             buttonI18nTag: 'passphrasebox-confirm-tx',
         };
 
@@ -20,6 +20,8 @@ class PassphraseBox extends Nimiq.Observable {
         this.options = Object.assign(defaults, options);
 
         this.$el = PassphraseBox._createElement($el, this.options);
+
+        this.$el.classList.toggle('hide-input', this.options.hideInput);
 
         this._passphraseInput = new PassphraseInput(this.$el.querySelector('[passphrase-input]'));
         this._passphraseInput.on(PassphraseInput.Events.VALID, isValid => this._onInputChangeValidity(isValid));
@@ -112,7 +114,9 @@ class PassphraseBox extends Nimiq.Observable {
     _onSubmit(event) {
         event.preventDefault();
         if (!this.options.hideInput && !this._isInputValid) return;
-        this.fire(PassphraseBox.Events.SUBMIT, this._passphraseInput.text);
+
+        const passphrase = !this.options.hideInput ? this._passphraseInput.text : undefined;
+        this.fire(PassphraseBox.Events.SUBMIT, passphrase);
     }
 
     _onCancel() {

--- a/src/request/create/Create.js
+++ b/src/request/create/Create.js
@@ -142,7 +142,7 @@ class Create {
         document.body.classList.add('loading');
         const key = new Key(this._selectedEntropy.serialize());
         // XXX Should we use utf8 encoding here instead?
-        const passphrase = Nimiq.BufferUtils.fromAscii(this._passphrase);
+        const passphrase = this._passphrase.length > 0 ? Nimiq.BufferUtils.fromAscii(this._passphrase) : undefined;
         await KeyStore.instance.put(key, passphrase);
 
         const keyPath = request.defaultKeyPath;

--- a/src/request/sign-transaction/BaseLayout.js
+++ b/src/request/sign-transaction/BaseLayout.js
@@ -93,7 +93,9 @@ class BaseLayout {
 
         this._passphraseBox.on(
             PassphraseBox.Events.SUBMIT,
-            passphrase => this._onConfirm(request, resolve, reject, passphrase),
+            /** @param {string} [passphrase] */ passphrase => {
+                this._onConfirm(request, resolve, reject, passphrase);
+            },
         );
         this._passphraseBox.on(PassphraseBox.Events.CANCEL, () => window.history.back());
 
@@ -110,7 +112,7 @@ class BaseLayout {
      * @param {ParsedSignTransactionRequest} request
      * @param {Function} resolve
      * @param {Function} reject
-     * @param {string} passphrase
+     * @param {string} [passphrase]
      * @returns {Promise<void>}
      * @private
      */
@@ -119,7 +121,7 @@ class BaseLayout {
 
         try {
             // XXX Passphrase encoding
-            const passphraseBuf = Nimiq.BufferUtils.fromAscii(passphrase);
+            const passphraseBuf = passphrase ? Nimiq.BufferUtils.fromAscii(passphrase) : undefined;
             const key = await KeyStore.instance.get(request.keyInfo.id, passphraseBuf);
             if (!key) {
                 reject(new Error('Failed to retrieve key'));


### PR DESCRIPTION
Resolves https://github.com/nimiq/accounts/issues/31.

Prior to this PR, "unencrypted" keys where still encrypted with an empty Uint8Array. This PR fixes this (thus previously created "unencrypted" keys are no longer usable) and enables the PassphraseBox to properly display and offer the SUBMIT option when the key is not encrypted.