### PR TITLE
Replace window.close() with RPC-replying a special error

### DIFF
--- a/src/request/create/Create.js
+++ b/src/request/create/Create.js
@@ -121,7 +121,7 @@ class Create {
         /** @type HTMLAnchorElement */
         const $cancelLink = ($appName.parentNode);
         $cancelLink.classList.remove('display-none');
-        $cancelLink.addEventListener('click', () => window.close());
+        $cancelLink.addEventListener('click', () => { throw new Error('CANCEL'); });
 
         // Set up progress indicators
         /* eslint-disable no-new */

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -35,7 +35,7 @@ class ImportApi extends TopLevelApi {
         /** @type HTMLAnchorElement */
         const $cancelLink = ($appName.parentNode);
         $cancelLink.classList.remove('display-none');
-        $cancelLink.addEventListener('click', () => window.close());
+        $cancelLink.addEventListener('click', () => { throw new Error('CANCEL'); });
 
         this.run();
     }

--- a/src/request/sign-transaction/BaseLayout.js
+++ b/src/request/sign-transaction/BaseLayout.js
@@ -103,7 +103,7 @@ class BaseLayout {
         /** @type HTMLAnchorElement */
         const $cancelLink = ($appName.parentNode);
         $cancelLink.classList.remove('display-none');
-        $cancelLink.addEventListener('click', () => window.close());
+        $cancelLink.addEventListener('click', () => reject(new Error('CANCEL')));
     }
 
     /**


### PR DESCRIPTION
Enabled nimiq/accounts#e6b3b95119928d00741afcf5e7e91746a1ae923b, by replying a special `Error('CANCEL')`, the error is handed through to the caller and the request is cancelled.