### PR TITLE
Derive a new account for a wallet

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",

--- a/client/src/KeyguardClient.ts
+++ b/client/src/KeyguardClient.ts
@@ -16,6 +16,8 @@ import {
     ExportWordsResult,
     ExportFileRequest,
     ExportFileResult,
+    DeriveAddressRequest,
+    DeriveAddressResult,
     KeyInfoObject,
     AccountInfo,
 } from './RequestTypes';
@@ -89,6 +91,11 @@ export class KeyguardClient {
     public async signMessage(request: SignMessageRequest,
                              requestBehavior = this._defaultBehavior): Promise<SignMessageResult> {
         return this._request(requestBehavior,  KeyguardCommand.SIGN_MESSAGE, [request]);
+    }
+
+    public async deriveAddress(request: DeriveAddressRequest,
+                               requestBehavior = this._defaultBehavior): Promise<DeriveAddressResult> {
+        return this._request(requestBehavior,  KeyguardCommand.DERIVE_ADDRESS, [request]);
     }
 
     /* IFRAME REQUESTS */

--- a/client/src/RequestTypes.ts
+++ b/client/src/RequestTypes.ts
@@ -6,6 +6,7 @@ export enum KeyguardCommand {
     EXPORT_FILE = 'export-file',
     SIGN_TRANSACTION = 'sign-transaction',
     SIGN_MESSAGE = 'sign-message',
+    DERIVE_ADDRESS = 'derive-address',
 
     // Iframe requests
     LIST = 'list',
@@ -113,6 +114,19 @@ export interface SignMessageRequest {
 export interface SignMessageResult {
     publicKey: Uint8Array;
     signature: Uint8Array;
+}
+
+export interface DeriveAddressRequest {
+    appName: string;
+    keyId: string;
+    keyLabel?: string;
+    baseKeyPath: string;
+    indicesToDerive: string[];
+}
+
+export interface DeriveAddressResult {
+    keyPath: string;
+    address: Uint8Array;
 }
 
 export type RpcResult = CreateResult

--- a/src/components/PassphraseBox.js
+++ b/src/components/PassphraseBox.js
@@ -16,7 +16,7 @@ class PassphraseBox extends Nimiq.Observable {
 
         super();
 
-        /** @type {object} */
+        /** @type {{bgColor: string, hideInput: boolean, buttonI18nTag: string}} */
         this.options = Object.assign(defaults, options);
 
         this.$el = PassphraseBox._createElement($el, this.options);
@@ -36,7 +36,7 @@ class PassphraseBox extends Nimiq.Observable {
 
     /**
      * @param {?HTMLFormElement} [$el]
-     * @param {object} options
+     * @param {{bgColor: string, hideInput: boolean, buttonI18nTag: string}} options
      * @returns {HTMLFormElement}
      */
     static _createElement($el, options) {
@@ -47,6 +47,7 @@ class PassphraseBox extends Nimiq.Observable {
         // all possible i18n tags and texts have to be specified here in the below format to
         // enable the validator to find them with its regular expression.
         /* eslint-disable max-len */
+        /** @type {{[i18nTag: string]: string}} */
         const buttonVersions = {
             'passphrasebox-continue': '<button class="submit" data-i18n="passphrasebox-continue">Continue</button>',
             'passphrasebox-log-in': '<button class="submit" data-i18n="passphrasebox-log-in">Log in to your wallet</button>',

--- a/src/lib/Key.js
+++ b/src/lib/Key.js
@@ -88,7 +88,8 @@ class Key {
         return `UserFriendly ${id}`;
     }
 }
+
 Key.Type = {
-    LEGACY: /** @type {Key.Type} */ 0,
-    BIP39: /** @type {Key.Type} */ 1,
+    LEGACY: 0,
+    BIP39: 1,
 };

--- a/src/request/derive-address/DeriveAddress.css
+++ b/src/request/derive-address/DeriveAddress.css
@@ -1,0 +1,20 @@
+.page p {
+    margin: 4rem;
+}
+
+.page p + p {
+    margin-top: -2.5rem;
+}
+
+.page#choose-identicon .page-body {
+    position: relative;
+}
+
+.page-body, .page-footer {
+    /* TODO: Move this to common.css, but have to adapt sign-transaction stylings */
+    background: #fafafa;
+    align-items: center;
+
+    border-bottom-left-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+}

--- a/src/request/derive-address/DeriveAddress.css
+++ b/src/request/derive-address/DeriveAddress.css
@@ -6,6 +6,16 @@
     margin-top: -2.5rem;
 }
 
+.passphrase-icon-text {
+    padding: 4rem 6.75rem;
+    display: flex;
+    flex-direction: row;
+}
+
+.passphrase-icon-text p {
+    margin: 2rem 0 0 5rem;
+}
+
 .page#choose-identicon .page-body {
     position: relative;
 }

--- a/src/request/derive-address/DeriveAddress.js
+++ b/src/request/derive-address/DeriveAddress.js
@@ -1,0 +1,116 @@
+/* global Nimiq */
+/* global DerivedIdenticonSelector */
+/* global PassphraseBox */
+/* global KeyStore */
+
+class DeriveAddress {
+    /**
+     * @param {ParsedDeriveAddressRequest} request
+     * @param {Function} resolve
+     * @param {Function} reject
+     */
+    constructor(request, resolve, reject) {
+        this._request = request;
+        this._resolve = resolve;
+        this._reject = reject;
+
+        /** @type {HTMLFormElement} */
+        const $passphraseBox = (document.querySelector('.passphrase-box'));
+
+        /** @type {HTMLDivElement} */
+        const $identiconSelector = (document.querySelector('.identicon-selector'));
+
+        // Create components
+
+        this._passphraseBox = new PassphraseBox($passphraseBox, {
+            hideInput: !request.keyInfo.encrypted,
+            buttonI18nTag: 'passphrasebox-continue',
+        });
+        this._identiconSelector = new DerivedIdenticonSelector($identiconSelector);
+
+        // Wire up logic
+
+        this._passphraseBox.on(
+            PassphraseBox.Events.SUBMIT,
+            async /** @param {string|undefined} passphrase */ passphrase => {
+                await this._initIdenticonSelector(passphrase);
+                window.location.hash = DeriveAddress.Pages.CHOOSE_IDENTICON;
+            },
+        );
+
+        this._passphraseBox.on(PassphraseBox.Events.CANCEL, () => {
+            this._reject(new Error('CANCEL'));
+        });
+
+        this._identiconSelector.on(
+            DerivedIdenticonSelector.Events.IDENTICON_SELECTED,
+            /** @param {{address: Nimiq.Address, keyPath: string}} selectedAddress */
+            selectedAddress => {
+                console.log(selectedAddress);
+
+                /** @type {DeriveAddressResult} */
+                const result = {
+                    address: selectedAddress.address.serialize(),
+                    keyPath: selectedAddress.keyPath,
+                };
+
+                this._resolve(result);
+            },
+        );
+
+        /** @type {HTMLElement} */
+        const $appName = (document.querySelector('#app-name'));
+        $appName.textContent = request.appName;
+        /** @type HTMLAnchorElement */
+        const $cancelLink = ($appName.parentNode);
+        $cancelLink.classList.remove('display-none');
+        $cancelLink.addEventListener('click', () => reject(new Error('CANCEL')));
+    } // constructor
+
+    /**
+     * @param {string} [passphrase]
+     */
+    async _initIdenticonSelector(passphrase) {
+        const passphraseBuffer = passphrase && passphrase.length > 0
+            ? Nimiq.BufferUtils.fromAscii(passphrase)
+            : undefined;
+
+        /** @type {Key|null} */
+        let key = null;
+        try {
+            key = await KeyStore.instance.get(this._request.keyInfo.id, passphraseBuffer);
+        } catch (e) {
+            console.error(e);
+            this._passphraseBox.onPassphraseIncorrect();
+            return;
+        }
+
+        if (!key) return; // Key existance is already checked during request parsing in Api class
+
+        const masterKey = new Nimiq.Entropy(key.secret).toExtendedPrivateKey();
+
+        const baseKeyPathArray = this._request.baseKeyPath.split('/');
+        const pathsToDerive = this._request.indicesToDerive.map(index => /** @type {string[]} */ ([])
+            .concat(baseKeyPathArray, index)
+            .join('/'));
+
+        this._identiconSelector.init(masterKey, pathsToDerive);
+    }
+
+    async run() {
+        if (this._request.keyInfo.encrypted) {
+            window.location.hash = DeriveAddress.Pages.PASSPHRASE;
+
+            // Async pre-load the crypto worker to reduce wait time at first decrypt attempt
+            Nimiq.CryptoWorker.getInstanceAsync();
+        } else {
+            await this._initIdenticonSelector();
+            window.location.hash = DeriveAddress.Pages.CHOOSE_IDENTICON;
+        }
+    }
+}
+
+DeriveAddress.Pages = {
+    PASSPHRASE: 'passphrase',
+    CHOOSE_IDENTICON: 'choose-identicon',
+};

--- a/src/request/derive-address/DeriveAddress.js
+++ b/src/request/derive-address/DeriveAddress.js
@@ -86,11 +86,7 @@ class DeriveAddress {
         if (!key) return; // Key existence is already checked during request parsing in DeriveAddressApi class
 
         const masterKey = new Nimiq.Entropy(key.secret).toExtendedPrivateKey();
-
-        const baseKeyPathArray = this._request.baseKeyPath.split('/');
-        const pathsToDerive = this._request.indicesToDerive.map(index => /** @type {string[]} */ ([])
-            .concat(baseKeyPathArray, index)
-            .join('/'));
+        const pathsToDerive = this._request.indicesToDerive.map(index => `${this._request.baseKeyPath}/${index}`);
 
         this._identiconSelector.init(masterKey, pathsToDerive);
     }

--- a/src/request/derive-address/DeriveAddress.js
+++ b/src/request/derive-address/DeriveAddress.js
@@ -100,6 +100,7 @@ class DeriveAddress {
     async run() {
         if (this._request.keyInfo.encrypted) {
             window.location.hash = DeriveAddress.Pages.PASSPHRASE;
+            this._passphraseBox.focus();
 
             // Async pre-load the crypto worker to reduce wait time at first decrypt attempt
             Nimiq.CryptoWorker.getInstanceAsync();

--- a/src/request/derive-address/DeriveAddress.js
+++ b/src/request/derive-address/DeriveAddress.js
@@ -46,8 +46,6 @@ class DeriveAddress {
             DerivedIdenticonSelector.Events.IDENTICON_SELECTED,
             /** @param {{address: Nimiq.Address, keyPath: string}} selectedAddress */
             selectedAddress => {
-                console.log(selectedAddress);
-
                 /** @type {DeriveAddressResult} */
                 const result = {
                     address: selectedAddress.address.serialize(),
@@ -85,7 +83,7 @@ class DeriveAddress {
             return;
         }
 
-        if (!key) return; // Key existance is already checked during request parsing in Api class
+        if (!key) return; // Key existence is already checked during request parsing in DeriveAddressApi class
 
         const masterKey = new Nimiq.Entropy(key.secret).toExtendedPrivateKey();
 

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -43,7 +43,7 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
         }
 
         if (!request.baseKeyPath || !Nimiq.ExtendedPrivateKey.isValidPath(request.baseKeyPath)) {
-            throw new Error('Invalid defaultKeyPath');
+            throw new Error('Invalid baseKeyPath');
         }
 
         if (!request.indicesToDerive || !(request.indicesToDerive instanceof Array)) {

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -1,0 +1,61 @@
+/* global TopLevelApi */
+/* global DeriveAddress */
+/* global Key */
+/* global KeyStore */
+/* global Nimiq */
+
+class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-vars
+    /**
+     * @param {DeriveAddressRequest} request
+     */
+    async onRequest(request) {
+        const parsedRequest = await DeriveAddressApi._parseRequest(request);
+        const handler = new DeriveAddress(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
+        handler.run();
+    }
+
+    /**
+     * @param {DeriveAddressRequest} request
+     * @returns {Promise<ParsedDeriveAddressRequest>}
+     * @private
+     */
+    static async _parseRequest(request) {
+        if (!request) {
+            throw new Error('Empty request');
+        }
+
+        if (!request.appName || typeof request.appName !== 'string') {
+            throw new Error('appName is required');
+        }
+
+        if (!request.keyId || typeof request.keyId !== 'string') {
+            throw new Error('keyId is required');
+        }
+
+        // Check that key exists.
+        const keyInfo = await KeyStore.instance.getInfo(request.keyId);
+        if (!keyInfo) {
+            throw new Error('Unknown keyId');
+        }
+
+        if (keyInfo.type === Key.Type.LEGACY) {
+            throw new Error('Cannot derive addresses for single-account wallets');
+        }
+
+        if (!request.baseKeyPath || !Nimiq.ExtendedPrivateKey.isValidPath(request.baseKeyPath)) {
+            throw new Error('Invalid defaultKeyPath');
+        }
+
+        if (!request.indicesToDerive || !(request.indicesToDerive instanceof Array)) {
+            throw new Error('Invalid indicesToDerive');
+        }
+
+        return {
+            appName: request.appName,
+            keyInfo,
+            keyLabel: request.keyLabel,
+            baseKeyPath: request.baseKeyPath,
+            indicesToDerive: request.indicesToDerive,
+        };
+    }
+}

--- a/src/request/derive-address/DerivedIdenticonSelector.js
+++ b/src/request/derive-address/DerivedIdenticonSelector.js
@@ -1,0 +1,180 @@
+/* global Nimiq */
+/* global I18n */
+/* global Identicon */
+
+class DerivedIdenticonSelector extends Nimiq.Observable {
+    /**
+     * @param {HTMLElement} [$el]
+     */
+    constructor($el) {
+        super();
+
+        this._clearSelection = this._clearSelection.bind(this);
+        this._onSelectionConfirmed = this._onSelectionConfirmed.bind(this);
+
+        this.$el = DerivedIdenticonSelector._createElement($el);
+
+        /** @type {number} */
+        this._page = 1;
+
+        /** @type {string[]} */
+        this._pathsToDerive = [];
+
+        /** @type {{ [address: string]: { address: Nimiq.Address, keyPath: string } }} */
+        this._derivedAddresses = {};
+
+        /** @type {?string} */
+        this._selectedAddress = null;
+
+        this.$identicons = /** @type {HTMLElement} */ (this.$el.querySelector('.identicons'));
+        this.$confirmButton = /** @type {HTMLElement} */ (this.$el.querySelector('.backdrop button'));
+        this.$generateMoreButton = /** @type {HTMLElement} */ (this.$el.querySelector('.generate-more'));
+        this.$backdrop = /** @type {HTMLElement} */ (this.$el.querySelector('.backdrop'));
+
+        this.$generateMoreButton.addEventListener('click', this.nextPage.bind(this));
+        this.$backdrop.addEventListener('click', this._clearSelection);
+        this.$confirmButton.addEventListener('click', this._onSelectionConfirmed);
+    }
+
+    /**
+     * @param {HTMLElement} [$el]
+     *
+     * @returns {HTMLElement}
+     */
+    static _createElement($el) {
+        $el = $el || document.createElement('div');
+        $el.classList.add('identicon-selector');
+
+        $el.innerHTML = `
+            <div class="identicons">
+                <div class="loading center">
+                    <div class="loading-animation"></div>
+                    <h2 data-i18n="identicon-selector-loading">Mixing colors</h2>
+                </div>
+            </div>
+            <button class="generate-more">Generate new</button>
+
+            <div class="backdrop center">
+                <button data-i18n="identicon-selector-button-select">Select</button>
+                <a tabindex="0" class="secondary" data-i18n="identicon-selector-link-back">Back</a>
+            </div>`;
+
+        I18n.translateDom($el);
+        return $el;
+    }
+
+    /**
+     * @returns {HTMLElement}
+     */
+    getElement() {
+        return this.$el;
+    }
+
+    /**
+     * @param {Nimiq.ExtendedPrivateKey} masterKey
+     * @param {string[]} pathsToDerive
+     */
+    init(masterKey, pathsToDerive) {
+        /** @type {Nimiq.ExtendedPrivateKey} */
+        this._masterKey = masterKey;
+
+        /** @type {string[]} */
+        this._pathsToDerive = pathsToDerive;
+
+        this.generateIdenticons(this._masterKey, this._pathsToDerive, this._page);
+    }
+
+    nextPage() {
+        if (!this._masterKey) return;
+        this._page += 1;
+        if (this._page > 2) this._page = 1;
+        this.generateIdenticons(this._masterKey, this._pathsToDerive, this._page);
+    }
+
+    /**
+     * @param {Nimiq.ExtendedPrivateKey} masterKey
+     * @param {string[]} pathsToDerive
+     * @param {number} page
+     */
+    generateIdenticons(masterKey, pathsToDerive, page) {
+        this.$el.classList.remove('active');
+
+        /** @type {{ [address: string]: { address: Nimiq.Address, keyPath: string } }} */
+        const derivedAddresses = {};
+
+        const firstIndex = 7 * (page - 1);
+        const lastIndex = (7 * page) - 1;
+
+        for (let i = firstIndex; i <= lastIndex; i++) {
+            const key = masterKey.derivePath(pathsToDerive[i]);
+            const address = key.toAddress();
+            derivedAddresses[address.toUserFriendlyAddress()] = {
+                address,
+                keyPath: pathsToDerive[i],
+            };
+        }
+
+        this._derivedAddresses = derivedAddresses;
+
+        this.$identicons.textContent = '';
+
+        Object.keys(derivedAddresses).forEach(address => {
+            const $wrapper = document.createElement('div');
+            $wrapper.classList.add('wrapper');
+
+            const identicon = new Identicon(address);
+            const $identicon = identicon.getElement();
+
+            const $address = document.createElement('div');
+            $address.classList.add('address');
+            $address.textContent = address;
+
+            $wrapper.appendChild($identicon);
+            $wrapper.appendChild($address);
+
+            $wrapper.addEventListener('click', () => this._onIdenticonSelected($wrapper, address));
+
+            this.$identicons.appendChild($wrapper);
+        });
+
+        setTimeout(() => this.$el.classList.add('active'), 100);
+    }
+
+    /**
+     * @param {HTMLElement} $el
+     * @param {string} address
+     * @private
+     */
+    _onIdenticonSelected($el, address) {
+        const $returningIdenticon = this.$el.querySelector('.wrapper.returning');
+        if ($returningIdenticon) {
+            $returningIdenticon.classList.remove('returning');
+        }
+
+        this._selectedAddress = address;
+        this.$selectedIdenticon = $el;
+        this.$el.classList.add('selected');
+        $el.classList.add('selected');
+    }
+
+    /**
+     * @private
+     */
+    _onSelectionConfirmed() {
+        if (!this._selectedAddress) throw new Error('Invalid state');
+        this.fire(DerivedIdenticonSelector.Events.IDENTICON_SELECTED, this._derivedAddresses[this._selectedAddress]);
+    }
+
+    _clearSelection() {
+        if (this.$selectedIdenticon) {
+            this.$selectedIdenticon.classList.add('returning');
+            this.$selectedIdenticon.classList.remove('selected');
+        }
+
+        this.$el.classList.remove('selected');
+    }
+}
+
+DerivedIdenticonSelector.Events = {
+    IDENTICON_SELECTED: 'identicon-selected',
+};

--- a/src/request/derive-address/DerivedIdenticonSelector.js
+++ b/src/request/derive-address/DerivedIdenticonSelector.js
@@ -86,7 +86,7 @@ class DerivedIdenticonSelector extends Nimiq.Observable {
         if (!this._masterKey) throw new Error('Master key not set, call init() first');
 
         this._page += 1;
-        if (this._page > 2) this._page = 1;
+        if (this._page > Math.floor(this._pathsToDerive.length / 7)) this._page = 1;
         this.generateIdenticons(this._masterKey, this._pathsToDerive, this._page);
     }
 

--- a/src/request/derive-address/DerivedIdenticonSelector.js
+++ b/src/request/derive-address/DerivedIdenticonSelector.js
@@ -82,7 +82,9 @@ class DerivedIdenticonSelector extends Nimiq.Observable {
     }
 
     nextPage() {
-        if (!this._masterKey) return;
+        // This check is mainly to make Typescript happy, as "this._masterKey is potentially undefined"
+        if (!this._masterKey) throw new Error('Master key not set, call init() first');
+
         this._page += 1;
         if (this._page > 2) this._page = 1;
         this.generateIdenticons(this._masterKey, this._pathsToDerive, this._page);

--- a/src/request/derive-address/DerivedIdenticonSelector.js
+++ b/src/request/derive-address/DerivedIdenticonSelector.js
@@ -9,9 +9,6 @@ class DerivedIdenticonSelector extends Nimiq.Observable {
     constructor($el) {
         super();
 
-        this._clearSelection = this._clearSelection.bind(this);
-        this._onSelectionConfirmed = this._onSelectionConfirmed.bind(this);
-
         this.$el = DerivedIdenticonSelector._createElement($el);
 
         /** @type {number} */
@@ -32,8 +29,8 @@ class DerivedIdenticonSelector extends Nimiq.Observable {
         this.$backdrop = /** @type {HTMLElement} */ (this.$el.querySelector('.backdrop'));
 
         this.$generateMoreButton.addEventListener('click', this.nextPage.bind(this));
-        this.$backdrop.addEventListener('click', this._clearSelection);
-        this.$confirmButton.addEventListener('click', this._onSelectionConfirmed);
+        this.$backdrop.addEventListener('click', this._clearSelection.bind(this));
+        this.$confirmButton.addEventListener('click', this._onSelectionConfirmed.bind(this));
     }
 
     /**

--- a/src/request/derive-address/IdenticonSelector.css
+++ b/src/request/derive-address/IdenticonSelector.css
@@ -1,0 +1,146 @@
+.identicon-selector {
+    width: 100%;
+    text-align: center;
+}
+
+.identicon-selector .wrapper {
+    width: 14.25rem;
+    height: 14.25rem;
+    position: absolute;
+    will-change: transform;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+.identicon-selector .wrapper .identicon {
+    width: 100%;
+    height: 100%;
+    animation: pop-in 500ms ease;
+    animation-fill-mode: forwards;
+    transform: scale(0);
+}
+
+.identicon-selector .wrapper .address {
+    visibility: hidden;
+    text-align: center;
+    transform: scale(0.5);
+    margin-top: 5rem;
+    color: white;
+}
+
+@keyframes pop-in {
+    from { transform: scale(0); }
+    to   { transform: scale(1); }
+}
+
+.identicon-selector .wrapper .identicon,
+.identicon-selector .wrapper .identicon img,
+.identicon-selector .wrapper .address {
+    transition: transform 500ms;
+}
+
+.identicon-selector .wrapper:hover {
+    cursor: pointer;
+}
+
+.identicon-selector .identicons {
+    display: flex;
+    flex-grow: 1;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 41rem;
+    position: relative;
+}
+
+.identicon-selector .wrapper:nth-child(1) { transform: translate(  0.0rem, -14.25rem); }
+.identicon-selector .wrapper:nth-child(2) { transform: translate(-12.5rem,  -7.25rem); }
+.identicon-selector .wrapper:nth-child(3) { transform: translate( 12.5rem,  -7.25rem); }
+.identicon-selector .wrapper:nth-child(4) { transform: translate(  0.0rem,   0.00rem); }
+.identicon-selector .wrapper:nth-child(5) { transform: translate(-12.5rem,   7.25rem); }
+.identicon-selector .wrapper:nth-child(6) { transform: translate( 12.5rem,   7.25rem); }
+.identicon-selector .wrapper:nth-child(7) { transform: translate(  0.0rem,  14.25rem); }
+
+.identicon-selector .wrapper:nth-child(1) .identicon { animation-delay: 100ms; }
+.identicon-selector .wrapper:nth-child(2) .identicon { animation-delay: 150ms; }
+.identicon-selector .wrapper:nth-child(3) .identicon { animation-delay: 150ms; }
+.identicon-selector .wrapper:nth-child(4) .identicon { animation-delay: 200ms; }
+.identicon-selector .wrapper:nth-child(5) .identicon { animation-delay: 250ms; }
+.identicon-selector .wrapper:nth-child(6) .identicon { animation-delay: 250ms; }
+.identicon-selector .wrapper:nth-child(7) .identicon { animation-delay: 300ms; }
+
+
+.identicon-selector .generate-more {
+    background: #e5e5e5;
+    padding: 8px 14px;
+    width: unset;
+    height: unset;
+    font-size: 14px;
+    line-height: 0.86;
+    box-shadow: unset;
+    text-transform: unset;
+    letter-spacing: 0;
+    color: black;
+    margin: 4rem 0;
+}
+
+.identicon-selector .backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: 1;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 500ms;
+    will-change: opacity;
+    box-sizing: border-box;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-flow: column;
+}
+
+.identicon-selector .backdrop button {
+    opacity: 0;
+    transition: transform 500ms;
+    will-change: transform;
+    transition-delay: 300ms;
+    position: absolute;
+    bottom: 6rem;
+    pointer-events: none;
+    margin: 0;
+}
+
+.identicon-selector .backdrop .secondary {
+    position: absolute;
+    margin-bottom: 2rem;
+    bottom: 0;
+}
+
+.identicon-selector.selected .backdrop,
+.identicon-selector.selected .backdrop button {
+    opacity: 1;
+    pointer-events: all;
+}
+
+.identicon-selector .wrapper.selected,
+.identicon-selector .wrapper.returning {
+    z-index: 3;
+    transition: transform 500ms;
+    transition-delay: 0s !important;
+}
+
+.identicon-selector .wrapper.selected {
+    transform: translateY(-5rem);
+    width: 100%;
+    pointer-events: none;
+}
+
+.identicon-selector .wrapper.selected img {
+    transform: scale(1.5);
+}
+
+.identicon-selector .wrapper.selected .address {
+    visibility: visible;
+    transform: scale(1.1);
+}

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <!-- TODO: Don't use nimiq-network.com for releases -->
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self' 'unsafe-eval' https://cdn.nimiq.com https://cdn.nimiq-network.com;
+          img-src http: https: blob: data:; child-src 'self' blob:; style-src 'self';">
+    <title>Nimiq Keyguard</title>
+
+    <script defer src="https://cdn.nimiq-network.com/branches/master/web-offline.js"></script>
+    <script defer src="../../lib/RpcServer.es.js"></script>
+    <script defer src="../../lib/Key.js"></script>
+    <script defer src="../../lib/KeyInfo.js"></script>
+    <script defer src="../../lib/KeyStore.js"></script>
+    <script defer src="../../lib/AccountStore.js"></script>
+    <script defer src="../../lib/Iqons.js"></script>
+    <script defer src="../../lib/BrowserDetection.js"></script>
+    <script defer src="../../lib/I18n.js"></script>
+    <script defer src="../../lib/CookieJar.js"></script>
+    <script defer src="../../lib/AnimationUtils.js"></script>
+    <script defer src="../../translations/index.js"></script>
+    <script defer src="../../common.js"></script>
+    <script defer src="../../components/Identicon.js"></script>
+    <script defer src="../../components/PassphraseInput.js"></script>
+    <script defer src="../../components/PassphraseBox.js"></script>
+    <script defer src="../TopLevelApi.js"></script>
+    <script defer src="DerivedIdenticonSelector.js"></script>
+    <script defer src="DeriveAddress.js"></script>
+    <script defer src="DeriveAddressApi.js"></script>
+    <script defer src="index.js"></script>
+
+    <link rel="stylesheet" href="../../nimiq-style.css">
+    <link rel="stylesheet" href="../../common.css">
+    <link rel="stylesheet" href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" href="../../components/PassphraseBox.css">
+    <link rel="stylesheet" href="./IdenticonSelector.css">
+    <link rel="stylesheet" href="./DeriveAddress.css">
+</head>
+<body>
+    <div class="header-top">
+        <div class="nimiq-app-name">
+            <span class="nimiq-logo"></span>
+        </div>
+    </div>
+
+    <div id="app">
+        <div class="flex-grow"></div>
+
+        <div id="passphrase" class="page">
+            <div class="page-header">
+                <h1 data-i18n="derive-address-heading-passphrase">Unlock your Wallet</h1>
+            </div>
+
+            <div class="page-body">
+                <p data-i18n="derive-address-passphrase-text">Please enter your password to add an account to your wallet.</p>
+            </div>
+
+            <div class="page-footer">
+                <form class="passphrase-box"></form>
+            </div>
+        </div>
+
+        <div id="choose-identicon" class="page">
+            <div class="page-header">
+                <h1 data-i18n="derive-address-heading-choose-identicon">Choose your account avatar</h1>
+            </div>
+
+            <div class="page-body">
+                <div>
+                    <p data-i18n="derive-address-text-select-avatar">Select an avatar for your new account from the selection below.</p>
+                </div>
+                <div class="identicon-selector"></div>
+            </div>
+        </div>
+
+        <a tabindex="0" class="global-close display-none">Back to <span id="app-name"></span></a>
+
+        <div class="flex-grow"></div>
+
+        <div id="loading" class="page">
+            <div class="loading-animation"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -55,7 +55,10 @@
             </div>
 
             <div class="page-body">
-                <p data-i18n="derive-address-passphrase-text">Please enter your password to add an account to your wallet.</p>
+                <div class="passphrase-icon-text">
+                    <div class="icon-keyfile-locked"></div>
+                    <p data-i18n="derive-address-passphrase-text">Please enter your passphrase to add another account to your wallet.</p>
+                </div>
             </div>
 
             <div class="page-footer">

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -51,7 +51,7 @@
 
         <div id="passphrase" class="page">
             <div class="page-header">
-                <h1 data-i18n="derive-address-heading-passphrase">Unlock your Wallet</h1>
+                <h1 data-i18n="derive-address-heading-passphrase">Unlock your wallet</h1>
             </div>
 
             <div class="page-body">

--- a/src/request/derive-address/index.js
+++ b/src/request/derive-address/index.js
@@ -1,0 +1,4 @@
+/* global DeriveAddressApi */
+/* global runKeyguard */
+
+runKeyguard(DeriveAddressApi);

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -127,6 +127,7 @@ class SignTransactionApi extends TopLevelApi {
     }
 }
 
+/** @type {{[layout: string]: any, standard: typeof LayoutStandard, checkout: typeof LayoutCheckout}} */
 SignTransactionApi.Layouts = {
     standard: LayoutStandard,
     checkout: LayoutCheckout,

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -105,6 +105,12 @@ const TRANSLATIONS = {
         'remove-key-confirm': 'Log out of your wallet',
         'remove-key-recovery-words': 'Recovery Words',
         'remove-key-back': 'Back to logout',
+
+        'derive-address-heading-passphrase': 'Unlock your Wallet',
+        'derive-address-passphrase-text': 'Please enter your password to add an account to your wallet.',
+        'derive-address-heading-choose-identicon': 'Choose your account avatar',
+        'derive-address-text-select-avatar': 'Select an avatar for your new account from the selection below.',
+
     },
     de: {
         _language: 'Deutsch',
@@ -218,6 +224,11 @@ const TRANSLATIONS = {
         'remove-key-confirm': 'Aus deinem Wallet ausloggen',
         'remove-key-recovery-words': 'Wiederherstellungswörter',
         'remove-key-back': 'Zurück zum logout',
+
+        'derive-address-heading-passphrase': 'Entschlüssele dein Wallet',
+        'derive-address-passphrase-text': 'Bitte gib deine Passphrase ein um einen Account deiner Wallet hinzuzufügen.',
+        'derive-address-heading-choose-identicon': 'Wähle deinen Konto Avatar',
+        'derive-address-text-select-avatar': 'Wähle einen Avatar für deinen neuen Account aus der Auswahl unten.',
     },
 };
 

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -106,7 +106,7 @@ const TRANSLATIONS = {
         'remove-key-recovery-words': 'Recovery Words',
         'remove-key-back': 'Back to logout',
 
-        'derive-address-heading-passphrase': 'Unlock your Wallet',
+        'derive-address-heading-passphrase': 'Unlock your wallet',
         'derive-address-passphrase-text': 'Please enter your passphrase to add another account to your wallet.',
         'derive-address-heading-choose-identicon': 'Choose your account avatar',
         'derive-address-text-select-avatar': 'Select an avatar for your new account from the selection below.',
@@ -138,7 +138,7 @@ const TRANSLATIONS = {
                                 + 'analogen Ort.',
         'recovery-words-continue-to-words': 'Weiter zu den Wiederherstellungswörtern',
 
-        'create-heading-choose-identicon': 'Wähle deinen Konto Avatar',
+        'create-heading-choose-identicon': 'Wähle deinen Konto-Avatar',
         'create-text-select-avatar': 'Wähle einen Avatar für den Standard-Account deiner Wallet aus der Auswahl unten.',
         'create-hint-more-accounts': 'Neue Konten kannst du später hinzufügen.',
         'create-heading-keyfile': 'Das ist deine Wallet Datei',
@@ -226,8 +226,8 @@ const TRANSLATIONS = {
         'remove-key-back': 'Zurück zum logout',
 
         'derive-address-heading-passphrase': 'Entschlüssele dein Wallet',
-        'derive-address-passphrase-text': 'Bitte gib deine Passphrase ein um einen Account deiner Wallet hinzuzufügen.',
-        'derive-address-heading-choose-identicon': 'Wähle deinen Konto Avatar',
+        'derive-address-passphrase-text': 'Bitte gib deine Passphrase ein um deiner Wallet einen weiteren Account hinzuzufügen.',
+        'derive-address-heading-choose-identicon': 'Wähle deinen Konto-Avatar',
         'derive-address-text-select-avatar': 'Wähle einen Avatar für deinen neuen Account aus der Auswahl unten.',
     },
 };

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -226,7 +226,8 @@ const TRANSLATIONS = {
         'remove-key-back': 'Zurück zum logout',
 
         'derive-address-heading-passphrase': 'Entschlüssele dein Wallet',
-        'derive-address-passphrase-text': 'Bitte gib deine Passphrase ein um deiner Wallet einen weiteren Account hinzuzufügen.',
+        'derive-address-passphrase-text': 'Bitte gib deine Passphrase ein um deiner Wallet einen weiteren Account '
+                                        + 'hinzuzufügen.',
         'derive-address-heading-choose-identicon': 'Wähle deinen Konto-Avatar',
         'derive-address-text-select-avatar': 'Wähle einen Avatar für deinen neuen Account aus der Auswahl unten.',
     },

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -107,7 +107,7 @@ const TRANSLATIONS = {
         'remove-key-back': 'Back to logout',
 
         'derive-address-heading-passphrase': 'Unlock your Wallet',
-        'derive-address-passphrase-text': 'Please enter your password to add an account to your wallet.',
+        'derive-address-passphrase-text': 'Please enter your passphrase to add another account to your wallet.',
         'derive-address-heading-choose-identicon': 'Choose your account avatar',
         'derive-address-text-select-avatar': 'Select an avatar for your new account from the selection below.',
 

--- a/types/Keyguard.d.ts
+++ b/types/Keyguard.d.ts
@@ -168,6 +168,27 @@ type RemoveKeyResult = {
     success: boolean
 }
 
+type DeriveAddressRequest = {
+    appName: string
+    keyId: string
+    keyLabel?: string
+    baseKeyPath: string
+    indicesToDerive: string[]
+}
+
+type ParsedDeriveAddressRequest = {
+    appName: string
+    keyInfo: KeyInfo
+    keyLabel?: string
+    baseKeyPath: string
+    indicesToDerive: string[]
+}
+
+type DeriveAddressResult = {
+    keyPath: string
+    address: Uint8Array
+}
+
 type KeyguardRequest = CreateRequest
     | ImportRequest
     | RemoveKeyRequest


### PR DESCRIPTION
Resolves #106.

If the wallet is encrypted, the passphrase page is shown:
![screenshot from 2018-11-08 21-58-19](https://user-images.githubusercontent.com/1828163/48227250-11583280-e3a2-11e8-8087-b2ab199b7640.png)

If not, the user is taken directly to the identicon selection:
![screenshot from 2018-11-08 21-58-32](https://user-images.githubusercontent.com/1828163/48227269-1f0db800-e3a2-11e8-8703-7b7c9e7533c1.png)
