### PR TITLE
Make sure an IDBTransaction is 'complete' before resolving

### DIFF
--- a/src/lib/KeyStore.js
+++ b/src/lib/KeyStore.js
@@ -221,7 +221,13 @@ class KeyStore {
             }),
         ]);
 
-        return (done instanceof Error) ? done : done[0];
+        // In case of rejection of any one of the above promises,
+        // the 'await' keyword makes sure that the error is thrown
+        // and this async function is itself rejected.
+
+        // Promise.all returns an array of resolved promises, but we are only
+        // interested in the request.result, which is the first item.
+        return done[0];
     }
 
     /**


### PR DESCRIPTION
It could sometimes happen, that a key was not stored in the Keyguard before returning to the Accounts Manager. Through online research, we learned that the `IDBRequest.onsuccess` does not necessarily relate to the data being written to disk. According to [MDN IDBTransaction documentation](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/oncomplete), the `IDBTransaction.oncomplete` event has this (pseudo)-guarantee. Thus we use the combination of the transaction's `oncomplete` and the requests `onsuccess` events to resolve the `KeyStore` methods.

This is really only relevant for writing data, but it doesn't hurt for reading it as well.