### PR TITLE
Use Chrome beta and add FirefoxHeadless in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ addons:
   chrome: stable
   firefox: latest
 
-before_install:
-  - export DISPLAY=:99.0
-  - CHROME_BIN=/usr/bin/google-chrome-stable
-
 script:
   - yarn typecheck
   - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   - node_modules
 
 addons:
-  chrome: stable
+  chrome: beta
   firefox: latest
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 
 addons:
   chrome: stable
+  firefox: latest
 
 before_install:
   - export DISPLAY=:99.0

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function (/** @type {any} */ config) {
 
         // list of files / patterns to load in the browser
         files: [
-            'https://cdn.nimiq-network.com/branches/master/web.js',
+            'https://cdn.nimiq-testnet.com/web-offline.js',
             'src/**/*js',
             'tests/**/*.spec.js'
         ],
@@ -56,18 +56,9 @@ module.exports = function (/** @type {any} */ config) {
         autoWatch: true,
 
 
-        // On travis in sudo:false mode (which is much faster to start) we have to run chrome without sandbox
-        customLaunchers: {
-            ChromeHeadlessNoSandbox: {
-                base: 'ChromeHeadless',
-                flags: ['--no-sandbox']
-            }
-        },
-
-
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: process.env.TRAVIS? ['ChromeHeadlessNoSandbox'] : ['ChromeHeadless'],
+        browsers: ['ChromeHeadless'],
 
 
         // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -55,21 +55,10 @@ module.exports = function (/** @type {any} */ config) {
         // enable / disable watching file and executing tests whenever any file changes
         autoWatch: true,
 
-        customLaunchers: {
-            Chrome_Travis_CI: {
-                base: 'Chrome',
-                flags: ['--disable-gpu']
-            },
-            Chrome_Headless_Travis_CI: {
-                base: 'ChromeHeadless',
-                flags: ['--disable-gpu']
-            },
-        },
-
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: process.env.TRAVIS ? ['FirefoxHeadless', 'Chrome_Headless_Travis_CI', 'Chrome_Travis_CI'] : ['Chrome', 'FirefoxHeadless'],
+        browsers: process.env.TRAVIS ? ['FirefoxHeadless'/*, 'ChromeHeadless'*/] : ['FirefoxHeadless', 'Chrome'],
 
 
         // Continuous Integration mode
@@ -78,6 +67,6 @@ module.exports = function (/** @type {any} */ config) {
 
         // Concurrency level
         // how many browser should be started simultaneous
-        concurrency: 1,
+        concurrency: 2,
     });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -55,10 +55,17 @@ module.exports = function (/** @type {any} */ config) {
         // enable / disable watching file and executing tests whenever any file changes
         autoWatch: true,
 
+        customLaunchers: {
+            Chrome_Travis_CI: {
+                base: 'Chrome',
+                flags: ['--no-sandbox']
+            }
+        },
+
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome'],
+        browsers: process.env.TRAVIS ? ['Chrome_Travis_CI'] : ['Chrome'],
 
 
         // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -69,7 +69,7 @@ module.exports = function (/** @type {any} */ config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: process.env.TRAVIS ? ['FirefoxHeadless', 'Chrome_Travis_CI', 'Chrome_Headless_Travis_CI'] : ['Chrome', 'FirefoxHeadless'],
+        browsers: process.env.TRAVIS ? ['FirefoxHeadless', 'Chrome_Headless_Travis_CI', 'Chrome_Travis_CI'] : ['Chrome', 'FirefoxHeadless'],
 
 
         // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -59,13 +59,17 @@ module.exports = function (/** @type {any} */ config) {
             Chrome_Travis_CI: {
                 base: 'Chrome',
                 flags: ['--no-sandbox']
-            }
+            },
+            Chrome_Headless_Travis_CI: {
+                base: 'ChromeHeadless',
+                flags: ['--no-sandbox']
+            },
         },
 
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: process.env.TRAVIS ? ['Chrome_Travis_CI'] : ['Chrome'],
+        browsers: process.env.TRAVIS ? ['Chrome_Travis_CI', 'Chrome_Headless_Travis_CI', 'FirefoxHeadless'] : ['Chrome', 'FirefoxHeadless'],
 
 
         // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = function (/** @type {any} */ config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['ChromeHeadless'],
+        browsers: ['Chrome'],
 
 
         // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,18 +58,18 @@ module.exports = function (/** @type {any} */ config) {
         customLaunchers: {
             Chrome_Travis_CI: {
                 base: 'Chrome',
-                flags: ['--no-sandbox']
+                flags: ['--disable-gpu']
             },
             Chrome_Headless_Travis_CI: {
                 base: 'ChromeHeadless',
-                flags: ['--no-sandbox']
+                flags: ['--disable-gpu']
             },
         },
 
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: process.env.TRAVIS ? ['Chrome_Travis_CI', 'Chrome_Headless_Travis_CI', 'FirefoxHeadless'] : ['Chrome', 'FirefoxHeadless'],
+        browsers: process.env.TRAVIS ? ['FirefoxHeadless', 'Chrome_Travis_CI', 'Chrome_Headless_Travis_CI'] : ['Chrome', 'FirefoxHeadless'],
 
 
         // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -58,7 +58,7 @@ module.exports = function (/** @type {any} */ config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: process.env.TRAVIS ? ['FirefoxHeadless'/*, 'ChromeHeadless'*/] : ['FirefoxHeadless', 'Chrome'],
+        browsers: process.env.TRAVIS ? ['FirefoxHeadless', 'ChromeHeadless'] : ['FirefoxHeadless', 'Chrome'],
 
 
         // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jasmine-core": "^3.1.0",
     "karma": "karma-runner/karma#94a6728de96b44788f7179ae1dc29602746d55a6",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-istanbuljs-reporter": "^0.2.0",
     "karma-jasmine": "^1.1.2",
     "nyc": "^12.0.2",

--- a/tests/DummyData.spec.js
+++ b/tests/DummyData.spec.js
@@ -3,6 +3,7 @@
 /* global Key */
 /* global KeyInfo */
 /* global KeyStore */
+
 beforeAll(async () => {
     await loadNimiq();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,6 +2187,11 @@ karma-chrome-launcher@^2.2.0:
     fs-access "^1.0.0"
     which "^1.2.1"
 
+karma-firefox-launcher@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz#2c47030452f04531eb7d13d4fc7669630bb93339"
+  integrity sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==
+
 karma-istanbuljs-reporter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/karma-istanbuljs-reporter/-/karma-istanbuljs-reporter-0.2.0.tgz#c94c883be912c49c3425442d8fe0a0bac348808f"


### PR DESCRIPTION
The `--no-sandbox` flag is not required anymore, since Travis moved their infrastructure from containers to VMs. The flag was only required for containers.

As such, `stable` `ChromeHeadless` does start in Travis, but runs into the Service/Web Worker issue. Regular `Chrome` doesn't start on Travis due to a `Error: /etc/machine-id contains 0 characters` error.

The root cause is apparently a regression bug in Chrome 71 headless, [found here](https://github.com/GoogleChrome/puppeteer/issues/3463) and [tracked here](https://bugs.chromium.org/p/chromium/issues/detail?id=902918).

Using the `beta` channel of Chrome works for Travis.