### PR TITLE
Remove breaking passphrase length checks

### DIFF
--- a/src/request/change-passphrase/ChangePassphrase.js
+++ b/src/request/change-passphrase/ChangePassphrase.js
@@ -1,6 +1,5 @@
 /* global PassphraseBox */
 /* global PassphraseSetterBox */
-/* global PassphraseInput */
 /* global KeyStore */
 /* global Errors */
 /* global Utf8Tools */
@@ -92,11 +91,6 @@ class ChangePassphrase {
         document.body.classList.add('loading');
         if (!this._key) {
             this._reject(new Errors.KeyguardError('Bypassed Password'));
-            return;
-        }
-        if (phrase && phrase.length < PassphraseInput.DEFAULT_MIN_LENGTH) {
-            this._setPassphraseBox.onPassphraseTooShort();
-            document.body.classList.remove('loading');
             return;
         }
 

--- a/src/request/change-passphrase/ChangePassphraseApi.js
+++ b/src/request/change-passphrase/ChangePassphraseApi.js
@@ -1,3 +1,4 @@
+/* global Nimiq */
 /* global TopLevelApi */
 /* global ChangePassphrase */
 /* global KeyStore */
@@ -20,6 +21,9 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         handler.run();
+
+        // Async pre-load the crypto worker to reduce wait time at first decrypt attempt
+        Nimiq.CryptoWorker.getInstanceAsync();
     }
 
     /**

--- a/src/request/create/Create.js
+++ b/src/request/create/Create.js
@@ -1,7 +1,6 @@
 /* global Nimiq */
 /* global IdenticonSelector */
 /* global PassphraseSetterBox */
-/* global PassphraseInput */
 /* global DownloadKeyfile */
 /* global PrivacyAgent */
 /* global RecoveryWords */
@@ -71,11 +70,6 @@ class Create {
         );
 
         this._passphraseSetter.on(PassphraseSetterBox.Events.SUBMIT, /** @param {string} passphrase */ passphrase => {
-            if (passphrase && passphrase.length < PassphraseInput.DEFAULT_MIN_LENGTH) {
-                this._passphraseSetter.onPassphraseTooShort();
-                document.body.classList.remove('loading');
-                return;
-            }
             this._passphrase = passphrase;
             // TODO Generate secret for key file
             this._downloadKeyfile.setSecret(new Uint8Array(0), true);

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -3,7 +3,6 @@
 /* global ImportWords */
 /* global PassphraseBox */
 /* global PassphraseSetterBox */
-/* global PassphraseInput */
 /* global Nimiq */
 /* global Key */
 /* global KeyStore */
@@ -145,11 +144,6 @@ class ImportApi extends TopLevelApi {
             this._passphraseBox.onPassphraseIncorrect();
             return;
         }
-        if (passphrase && passphrase.length < PassphraseInput.DEFAULT_MIN_LENGTH) {
-            this._passphraseSetterBox.onPassphraseTooShort();
-            this.$loading.style.display = 'none';
-            return;
-        }
 
         /** @type {{keyPath: string, address: Uint8Array}[]} */
         const addresses = [];
@@ -174,6 +168,7 @@ class ImportApi extends TopLevelApi {
             sessionStorage.setItem(ImportApi.SESSION_STORAGE_KEY_PREFIX + key.id, secretString);
         } else {
             this.reject(new Errors.KeyguardError(`Unkown key type ${key.type}`));
+            return;
         }
 
         /** @type {KeyguardRequest.ImportResult} */


### PR DESCRIPTION
The PassphraseBox and PassphraseSetterBox do this already and only fire the SUBMIT event when password has the correct minimum length.

These additional checks actually break working with PIN wallets, as they don't adapt to the `keyInfo.hasPin` flag.