### PR TITLE
Extract common and toplevel JS and CSS bundles

### DIFF
--- a/src/request/change-passphrase/index.html
+++ b/src/request/change-passphrase/index.html
@@ -13,36 +13,41 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../common.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../components/PassphraseSetterBox.js"></script>
-    <script defer src="../../components/PassphraseBox.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="ChangePassphrase.js"></script>
     <script defer src="ChangePassphraseApi.js"></script>
     <script defer src="index.js"></script>
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="./ChangePassphrase.css">
 </head>
 <body>

--- a/src/request/create/index.html
+++ b/src/request/create/index.html
@@ -13,22 +13,27 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../lib/AutoComplete.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
     <script defer src="../../lib/Iqons.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../common.js"></script>
     <script defer src="../../components/Identicon.js"></script>
     <script defer src="../../components/DownloadKeyfile.js"></script>
     <script defer src="../../components/PrivacyAgent.js"></script>
@@ -36,10 +41,8 @@
     <script defer src="../../components/ValidateWords.js"></script>
     <script defer src="../../components/RecoveryWordsInputField.js"></script>
     <script defer src="../../components/RecoveryWords.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
     <script defer src="../../components/PassphraseSetterBox.js"></script>
     <script defer src="../../components/ProgressIndicator.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="IdenticonSelector.js"></script>
     <script defer src="Create.js"></script>
     <script defer src="CreateApi.js"></script>
@@ -47,12 +50,14 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="../../components/DownloadKeyfile.css">
     <link rel="stylesheet" href="../../components/RecoveryWords.css">
     <link rel="stylesheet" href="../../components/RecoveryWordsInputField.css">

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -13,25 +13,28 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../lib/Iqons.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../common.js"></script>
     <script defer src="../../components/Identicon.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
-    <script defer src="../../components/PassphraseBox.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="DerivedIdenticonSelector.js"></script>
     <script defer src="DeriveAddress.js"></script>
     <script defer src="DeriveAddressApi.js"></script>
@@ -39,12 +42,14 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="./IdenticonSelector.css">
     <link rel="stylesheet" href="./DeriveAddress.css">
 </head>

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -13,29 +13,32 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../lib/AutoComplete.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../common.js"></script>
     <script defer src="../../components/PrivacyWarning.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
-    <script defer src="../../components/PassphraseBox.js"></script>
     <script defer src="../../components/DownloadKeyfile.js"></script>
     <script defer src="../../components/RecoveryWords.js"></script>
     <script defer src="../../components/RecoveryWordsInputField.js"></script>
     <script defer src="../../components/ValidateWords.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="ExportFile.js"></script>
     <script defer src="ExportWords.js"></script>
     <script defer src="Export.js"></script>
@@ -44,12 +47,14 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="../../components/DownloadKeyfile.css">
     <link rel="stylesheet" href="../../components/RecoveryWords.css">
     <link rel="stylesheet" href="../../components/RecoveryWordsInputField.css">

--- a/src/request/iframe/index.html
+++ b/src/request/iframe/index.html
@@ -4,14 +4,16 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-        <script defer src="../../lib/RpcServer.es.js"></script>
-        <script defer src="../../lib/BrowserDetection.js"></script>
-        <script defer src="../../lib/AccountStore.js"></script> <!-- @deprecated Only for database migration -->
-        <script defer src="../../lib/KeyStore.js"></script>
-        <script defer src="../../lib/Key.js"></script>
-        <script defer src="../../lib/KeyInfo.js"></script>
-        <script defer src="../../lib/CookieJar.js"></script>
-        <script defer src="../../common.js"></script>
+
+        <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+        <script defer bundle-common src="../../lib/KeyStore.js"></script>
+        <script defer bundle-common src="../../lib/Key.js"></script>
+        <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+        <script defer bundle-common src="../../lib/CookieJar.js"></script>
+        <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+        <script defer bundle-common src="../../lib/AccountStore.js"></script>
+        <script defer bundle-common src="../../common.js"></script>
+
         <script defer src="IFrameApi.js"></script>
         <script defer src="index.js"></script>
     </head>

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -13,46 +13,51 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../lib/AutoComplete.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
     <script defer src="../../lib/QrScanner.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
     <script defer src="../../lib/Iqons.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../common.js"></script>
     <script defer src="../../components/Identicon.js"></script>
     <script defer src="../../components/FileImport.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
-    <script defer src="../../components/PassphraseBox.js"></script>
     <script defer src="../../components/PassphraseSetterBox.js"></script>
     <script defer src="../../components/PrivacyAgent.js"></script>
     <script defer src="../../components/PrivacyWarning.js"></script>
     <script defer src="../../components/RecoveryWords.js"></script>
     <script defer src="../../components/RecoveryWordsInputField.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="ImportWords.js"></script>
     <script defer src="ImportApi.js"></script>
     <script defer src="index.js"></script>
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="../../components/FileImport.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
     <link rel="stylesheet" href="../../components/PrivacyAgent.css">
     <link rel="stylesheet" href="../../components/RecoveryWords.css">
     <link rel="stylesheet" href="./Import.css">

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -13,29 +13,32 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../lib/AutoComplete.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../common.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
-    <script defer src="../../components/PassphraseBox.js"></script>
     <script defer src="../../components/PrivacyWarning.js"></script>
     <script defer src="../../components/RecoveryWordsInputField.js"></script>
     <script defer src="../../components/RecoveryWords.js"></script>
     <script defer src="../../components/ValidateWords.js"></script>
     <script defer src="../../components/DownloadKeyfile.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="../export/ExportFile.js"></script>
     <script defer src="../export/ExportWords.js"></script>
     <script defer src="RemoveKey.js"></script>
@@ -44,12 +47,14 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="../../components/PrivacyAgent.css">
     <link rel="stylesheet" href="../../components/RecoveryWordsInputField.css">
     <link rel="stylesheet" href="../../components/RecoveryWords.css">

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -13,37 +13,42 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../lib/Iqons.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../common.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
-    <script defer src="../../components/PassphraseBox.js"></script>
     <script defer src="../../components/Identicon.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="SignMessageApi.js"></script>
     <script defer src="SignMessage.js"></script>
     <script defer src="index.js"></script>
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="SignMessage.css">
 </head>
 <body>

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -13,26 +13,29 @@
     <title>Nimiq Keyguard</title>
 
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
-    <script defer src="../../lib/ErrorConstants.js"></script>
-    <script defer src="../../lib/Errors.js"></script>
-    <script defer src="../../lib/RpcServer.es.js"></script>
-    <script defer src="../../lib/CookieJar.js"></script>
-    <script defer src="../../lib/BrowserDetection.js"></script>
-    <script defer src="../../lib/Key.js"></script>
-    <script defer src="../../lib/KeyInfo.js"></script>
-    <script defer src="../../lib/KeyStore.js"></script>
-    <script defer src="../../lib/AccountStore.js"></script>
+
+    <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/Key.js"></script>
+    <script defer bundle-common src="../../lib/KeyInfo.js"></script>
+    <script defer bundle-common src="../../lib/CookieJar.js"></script>
+    <script defer bundle-common src="../../lib/BrowserDetection.js"></script>
+    <script defer bundle-common src="../../lib/AccountStore.js"></script>
+    <script defer bundle-common src="../../common.js"></script>
+
+    <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
+    <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
+    <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
+    <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
+    <script defer bundle-toplevel src="../../lib/Errors.js"></script>
+    <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
+    <script defer bundle-toplevel src="../TopLevelApi.js"></script>
+    <script defer bundle-toplevel src="../../translations/index.js"></script>
+
     <script defer src="../../lib/Iqons.js"></script>
-    <script defer src="../../lib/I18n.js"></script>
-    <script defer src="../../lib/AnimationUtils.js"></script>
-    <script defer src="../../translations/index.js"></script>
-    <script defer src="../../lib/Utf8Tools.js"></script>
-    <script defer src="../../common.js"></script>
-    <script defer src="../../components/PassphraseInput.js"></script>
-    <script defer src="../../components/PassphraseBox.js"></script>
     <script defer src="../../components/Identicon.js"></script>
     <script defer src="../../components/PaymentInfoLine.js"></script>
-    <script defer src="../TopLevelApi.js"></script>
     <script defer src="BaseLayout.js"></script>
     <script defer src="LayoutStandard.js"></script>
     <script defer src="LayoutCheckout.js"></script>
@@ -41,12 +44,14 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli:400,600,700">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Mono&text=0123456789ABCDEFGHJKLMNPQRSTUVXY">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
-    <link rel="stylesheet" href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
-    <link rel="stylesheet" href="../../nimiq-style.css">
-    <link rel="stylesheet" href="../../common.css">
-    <link rel="stylesheet" href="../../components/PassphraseInput.css">
-    <link rel="stylesheet" href="../../components/PassphraseBox.css">
+
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../../node_modules/@nimiq/style/nimiq-style-icons.min.css">
+    <link rel="stylesheet" bundle-toplevel href="../../nimiq-style.css">
+    <link rel="stylesheet" bundle-toplevel href="../../common.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseInput.css">
+    <link rel="stylesheet" bundle-toplevel href="../../components/PassphraseBox.css">
+
     <link rel="stylesheet" href="../../components/PaymentInfoLine.css">
     <link rel="stylesheet" href="SignTransaction.css">
 </head>

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,8 +2,8 @@
 
 # Note: Not sure if we use this. It's not straightforward to install on OSX
 # if ! which envsubst > /dev/null 2>&1; then
-#  echo "You don't seem to have envsubst yet. Go get it! Using sed as an" \
-#    "alternative approach is to slow... :("
+#  echo "You don't seem to have envsubst yet. Go get it! Using sed as an " \
+#    "alternative approach is too slow... :("
 #  exit 1
 # fi
 
@@ -23,6 +23,10 @@ HASH=$(git rev-parse --short=8 HEAD)
 JS_BUNDLE="index.$HASH.js"
 CSS_BUNDLE="index.$HASH.css"
 
+JS_COMMON_BUNDLE="common.$HASH.js"
+JS_TOPLEVEL_BUNDLE="toplevel.$HASH.js"
+CSS_TOPLEVEL_BUNDLE="toplevel.$HASH.css"
+
 # bundle files for each request
 for DIR in src/request/*/ ; do
     REQUEST=$(basename $DIR)
@@ -32,62 +36,89 @@ for DIR in src/request/*/ ; do
     # create directory for request
     mkdir dist/request/$REQUEST
 
-    # get all local js files included in request's index.html
-    LIST_JS="$(grep '<script' $DIR/index.html | grep -v -E 'http://|https://' | cut -d\" -f2)"
+    # get all local js files included in request's index.html, which are not in a bundle
+    LIST_JS="$(grep '<script' $DIR/index.html | grep -v 'bundle-' | grep -v -E 'http://|https://' | cut -d\" -f2)"
 
     # concat them
     for url in $LIST_JS; do
-       cat $DIR/$url >> dist/request/$REQUEST/$JS_BUNDLE
+        cat $DIR/$url >> dist/request/$REQUEST/$JS_BUNDLE
     done
 
-    # get all local css files included in request's index.html
-    LIST_CSS="$(grep '<link' $DIR/index.html | grep -v -E 'http://|https://' | cut -d\" -f4)"
+    # get all local css files included in request's index.html, which are not in a bundle
+    LIST_CSS="$(grep '<link' $DIR/index.html | grep -v 'bundle-' | grep -v -E 'http://|https://' | cut -d\" -f4)"
 
     # concat them
     for url in $LIST_CSS; do
-       cat $DIR/$url >> dist/request/$REQUEST/$CSS_BUNDLE
+        cat $DIR/$url >> dist/request/$REQUEST/$CSS_BUNDLE
     done
 
-    # replace scripts and links by bundle in built index.html
-    # and replace CSP strings with ENV variables for configuration
+    # collect bundle files
+    LIST_JS_COMMON="$LIST_JS_COMMON$(grep '<script' $DIR/index.html | grep 'bundle-common' | cut -d\" -f2) "
+    LIST_JS_TOPLEVEL="$LIST_JS_TOPLEVEL$(grep '<script' $DIR/index.html | grep 'bundle-toplevel' | cut -d\" -f2) "
+
+    # replace scripts and links by bundles in built index.html
+    # ~~and replace CSP strings with ENV variables for configuration~~
     # XXX: using envsubst as a first suggestion. if it is kept, the one should
     #      make sure to whitelist only known environment variables in there :)
     # ENV_TO_REPLACE='' # e.g. '${VAR1} $VAR2'
     awk '
     BEGIN {
-      skip_script = 0
-      skip_link = 0
+        skip_script = 0
+        skip_link = 0
     }
     /<script.*https?/ {
-      print
-      next
+        print
+        next
     }
     /<script/ {
-      # Replace first script tag with bundle, delete all others
-      if (!skip_script) {
-        skip_script = 1
-        # Preserve whitespace / intendation. Note: 1 ist first array index in awk
-        split($0, space, "<")
-        print space[1] "<script defer src=\"/request/'${REQUEST}'/'${JS_BUNDLE}'\"></script>"
-      }
-      next
+        # Replace first script tag with bundles, delete all others
+        if (!skip_script) {
+            skip_script = 1
+            # Preserve whitespace / intendation. Note: 1 is first array index in awk
+            split($0, space, "<")
+            print space[1] "<script defer src=\"/request/'${JS_COMMON_BUNDLE}'\"></script>"
+            if("'$REQUEST'" != "iframe") {
+                print space[1] "<script defer src=\"/request/'${JS_TOPLEVEL_BUNDLE}'\"></script>"
+            }
+            print space[1] "<script defer src=\"/request/'${REQUEST}'/'${JS_BUNDLE}'\"></script>"
+        }
+        next
     }
     /<link.*https?/ {
-      print
-      next
+        print
+        next
     }
     /<link/ {
-      if (!skip_link) {
-        skip_link = 1
-        split($0, space, "<")
-        print space[1] "<link rel=\"stylesheet\" href=\"/request/'${REQUEST}'/'${CSS_BUNDLE}'\">"
-      }
-      next
+        if (!skip_link) {
+            skip_link = 1
+            split($0, space, "<")
+            print space[1] "<link rel=\"stylesheet\" href=\"/request/'${CSS_TOPLEVEL_BUNDLE}'\">"
+            print space[1] "<link rel=\"stylesheet\" href=\"/request/'${REQUEST}'/'${CSS_BUNDLE}'\">"
+        }
+        next
     }
     { print }
     ' $DIR/index.html > dist/request/${REQUEST}/index.html
 
     # | envsubst "${ENV_TO_REPLACE}"
+done
+
+# prepare bundle lists
+LIST_JS_COMMON=$(echo $LIST_JS_COMMON | tr " " "\n" | sort -ur) # sort common bundle reverse for nicer order
+LIST_JS_TOPLEVEL=$(echo $LIST_JS_TOPLEVEL | tr " " "\n" | sort -u)
+# for CSS the order is very important, so sorting is not possible, thus we have to put the list here manually
+LIST_CSS_TOPLEVEL="../../../node_modules/@nimiq/style/nimiq-style.min.css ../../../node_modules/@nimiq/style/nimiq-style-icons.min.css ../../nimiq-style.css ../../common.css ../../components/PassphraseInput.css ../../components/PassphraseBox.css"
+
+# generate bundle files
+# (since all urls are relative to request directories, we simply use the create request directory as the base)
+for url in $LIST_JS_COMMON; do
+    cat src/request/create/$url >> dist/request/$JS_COMMON_BUNDLE
+done
+for url in $LIST_JS_TOPLEVEL; do
+    cat src/request/create/$url >> dist/request/$JS_TOPLEVEL_BUNDLE
+done
+for url in $LIST_CSS_TOPLEVEL; do
+    cat src/request/create/$url >> dist/request/$CSS_TOPLEVEL_BUNDLE
 done
 
 # copy assets


### PR DESCRIPTION
Resolves #136.

Previous:
```bash
~$: du -h dist
168K	dist/request/sign-transaction
164K	dist/request/derive-address
160K	dist/request/sign-message
196K	dist/request/remove-key
52K	dist/request/iframe
216K	dist/request/import
148K	dist/request/change-passphrase
196K	dist/request/export
208K	dist/request/create
1,5M	dist/request
112K	dist/assets
288K	dist/lib
1,9M	dist
```
After:
```bash
~$: du -h dist
44K	dist/request/sign-transaction
40K	dist/request/derive-address
32K	dist/request/sign-message
72K	dist/request/remove-key
16K	dist/request/iframe
92K	dist/request/import
28K	dist/request/change-passphrase
68K	dist/request/export
88K	dist/request/create
612K	dist/request
112K	dist/assets
288K	dist/lib
1016K	dist
```

That's a **47.8% saving**.