### PR TITLE
Parse incoming requests

### DIFF
--- a/client/types/KeyguardRequest.d.ts
+++ b/client/types/KeyguardRequest.d.ts
@@ -50,12 +50,11 @@ declare namespace KeyguardRequest {
         recipientType?: Nimiq.Account.Type
         data?: Uint8Array
         flags?: number
-        networkId?: number
     }
 
     type ConstructTransaction<T extends TransactionInfo> = Transform<T,
         'sender' | 'senderType' | 'recipient' | 'recipientType' | 'value' | 'fee' |
-        'validityStartHeight' | 'data' | 'flags' | 'networkId',
+        'validityStartHeight' | 'data' | 'flags',
         { transaction: Nimiq.ExtendedTransaction }>
 
     type SignTransactionRequestLayout = 'standard' | 'checkout' | 'cashlink'

--- a/demos/SignTransaction.html
+++ b/demos/SignTransaction.html
@@ -106,7 +106,6 @@
             fee: txFee,
             data: Nimiq.BufferUtils.fromAscii(txData),
             validityStartHeight: 0,
-            networkId: Nimiq.GenesisConfig.NETWORK_ID,
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tools/build.sh",
     "test": "karma start",
     "typecheck": "tsc",
-    "lint": "eslint src tools",
+    "lint": "eslint src tools && if ( grep fit tests/lib/* ); then exit 1; else exit 0; fi",
     "lintfix": "eslint --fix src tools",
     "checkdeps": "node tools/dependencyValidator.js",
     "test-coverage": "karma start karma.conf.coverage.js",

--- a/src/lib/RequestParser.js
+++ b/src/lib/RequestParser.js
@@ -17,7 +17,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
 
     /**
      * @param {any} path
-     * @param {string} name
+     * @param {string} name -  name of the property, used in error case only
      * @returns {string}
      */
     parsePath(path, name) {
@@ -36,7 +36,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
 
     /**
      * @param {any} paths
-     * @param {string} name
+     * @param {string} name - name of the property, used in error case only
      * @returns {string[]}
      */
     parsePathsArray(paths, name) {
@@ -70,7 +70,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
         if (typeof label !== 'string') {
             throw new Errors.InvalidRequestError('Label must be of type string');
         }
-        if(label.length === 0) {
+        if (label.length === 0) {
             return undefined;
         }
         return label;
@@ -84,10 +84,10 @@ class RequestParser { // eslint-disable-line no-unused-vars
         if (!keyId) {
             throw new Errors.InvalidRequestError('keyId is required');
         }
-        if(typeof keyId !== 'string') {
+        if (typeof keyId !== 'string') {
             throw new Errors.InvalidRequestError('keyId must be of type string');
         }
-        const keyInfo= await KeyStore.instance.getInfo(keyId);
+        const keyInfo = await KeyStore.instance.getInfo(keyId);
         if (!keyInfo) {
             throw new Errors.KeyNotFoundError();
         }
@@ -103,7 +103,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
         if (!indicesArray || indicesArray.constructor !== Array) {
             throw new Errors.InvalidRequestError('indicesToDerive is required');
         }
-        if(indicesArray.length === 0) {
+        if (indicesArray.length === 0) {
             throw new Errors.InvalidRequestError('Indice array must not be empty');
         }
         indicesArray.forEach((/** @type {any} */index) => { // eslint-disable-line arrow-parens
@@ -152,8 +152,8 @@ class RequestParser { // eslint-disable-line no-unused-vars
             throw new Errors.InvalidRequestError('Sender and recipient must not match');
         }
 
-        const flags = request.flags || Nimiq.Transaction.Flag.NONE; // TODO verify
-        const data = request.data || new Uint8Array(0); // TODO verify
+        const flags = request.flags || Nimiq.Transaction.Flag.NONE; // TODO verify?
+        const data = request.data || new Uint8Array(0); // TODO verify?
 
         const networkId = request.networkId || Nimiq.GenesisConfig.NETWORK_ID;
         if (networkId !== Nimiq.GenesisConfig.NETWORK_ID) {

--- a/src/lib/RequestParser.js
+++ b/src/lib/RequestParser.js
@@ -1,6 +1,5 @@
 /* global Nimiq */
 /* global KeyStore */
-/* global Key */
 /* global Errors */
 /* global Utf8Tools */
 
@@ -189,6 +188,4 @@ class RequestParser { // eslint-disable-line no-unused-vars
         }
         return parsedUrl.origin;
     }
-
-
 }

--- a/src/lib/RequestParser.js
+++ b/src/lib/RequestParser.js
@@ -119,13 +119,13 @@ class RequestParser { // eslint-disable-line no-unused-vars
             throw new Errors.InvalidRequestError('Request must be an object');
         }
 
-        const sender = this.parseAddress(object.sender);
+        const sender = this.parseAddress(object.sender, 'sender');
         const senderType = object.senderType || Nimiq.Account.Type.BASIC;
         if (!accountTypes.has(senderType)) {
             throw new Errors.InvalidRequestError('Invalid sender type');
         }
 
-        const recipient = this.parseAddress(object.recipient);
+        const recipient = this.parseAddress(object.recipient, 'recipient');
         const recipientType = object.recipientType || Nimiq.Account.Type.BASIC;
         if (!accountTypes.has(recipientType)) {
             throw new Errors.InvalidRequestError('Invalid sender type');
@@ -152,14 +152,15 @@ class RequestParser { // eslint-disable-line no-unused-vars
 
     /**
      * @param {any} address
+     * @param {string} name
      * @returns {Nimiq.Address}
      */
-    parseAddress(address) {
+    parseAddress(address, name) {
         try {
             const nqAddress = new Nimiq.Address(address);
             return nqAddress;
         } catch (error) {
-            throw new Errors.InvalidRequestError(`recipient must be a valid Nimiq Address (${error.message})`);
+            throw new Errors.InvalidRequestError(`${name} must be a valid Nimiq Address (${error.message})`);
         }
     }
 
@@ -173,7 +174,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
             throw new Errors.InvalidRequestError('message must be a String or Uint8Array');
         }
         if (message.length < 255) return message;
-        throw new Errors.InvalidRequestError('message must not exceed 255 characters');
+        throw new Errors.InvalidRequestError('message must not exceed 255 bytes');
     }
 
     /**

--- a/src/lib/RequestParser.js
+++ b/src/lib/RequestParser.js
@@ -46,7 +46,6 @@ class RequestParser { // eslint-disable-line no-unused-vars
         if (paths.length === 0) {
             throw new Errors.InvalidRequestError(`${name} must not be empty`);
         }
-
         /** @type {string[]} */
         const requestedKeyPaths = [];
         paths.forEach((/** @type {any} */path) => { // eslint-disable-line arrow-parens
@@ -59,7 +58,6 @@ class RequestParser { // eslint-disable-line no-unused-vars
     }
 
     /**
-     * null or string with less than 63 bytes
      * @param {any} label
      * @returns {string | undefined}
      */
@@ -95,7 +93,6 @@ class RequestParser { // eslint-disable-line no-unused-vars
     }
 
     /**
-     *
      * @param {any} indicesArray
      * @returns {string[]}
      */
@@ -126,6 +123,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
      */
     parseTransaction(request) {
         const accountTypes = new Set([Nimiq.Account.Type.BASIC, Nimiq.Account.Type.VESTING, Nimiq.Account.Type.HTLC]);
+
         let sender;
         try {
             sender = new Nimiq.Address(request.sender);
@@ -190,7 +188,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
      */
     parseShopOrigin(url) {
         if (!url || typeof url !== 'string') {
-            throw new Errors.InvalidRequestError('url must be of type string');
+            throw new Errors.InvalidRequestError('shopOrigin must be of type string');
         }
         /** @type {URL?} */
         let parsedUrl;

--- a/src/lib/RequestParser.js
+++ b/src/lib/RequestParser.js
@@ -1,0 +1,128 @@
+/* global Nimiq */
+/* global KeyStore */
+/* global Errors */
+
+class RequestParser { // eslint-disable-line no-unused-vars
+    /**
+     *
+     * @param {any} request
+     * @param {string} requestType
+     * @returns {Promise<any>}
+     */
+    static async parse(request, requestType) {
+        // make sure request is not undefined
+        if (!request) {
+            throw new Errors.InvalidRequestError('Empty request');
+        }
+        const parsedRequest = {};
+
+        // every request needs to have an appName: string
+        parsedRequest.appName = RequestParser._parseAppName(request.appName);
+
+        // Create-/ImportRequest additionally needs to have a valid defaultKeyPath
+        if (requestType === 'CreateRequest' || requestType === 'ImportRequest') {
+            parsedRequest.defaultKeyPath = RequestParser._parsePath(request.defaultKeyPath, 'defaultKeyPath');
+            if (requestType === 'ImportRequest') {
+                // ImportRequest also needs to have an array of valid keys as requestedKeyPaths
+                parsedRequest.requestedKeyPaths = RequestParser._parsePathsArray(
+                    request.requestedKeyPaths,
+                    'requestedKeyPaths',
+                );
+                return parsedRequest;
+            }
+            return parsedRequest;
+        }
+        // all other requests are at least SimpleRequests, so they need to have a valid keyId and a keyLabel
+        parsedRequest.keyLabel = RequestParser._parseLabel(request.keyLabel);
+        parsedRequest.keyInfo = await RequestParser._parseKeyId(request.keyId);
+        if (requestType === 'SimpleRequest') {
+            return parsedRequest;
+        }
+        return parsedRequest;
+    }
+
+    /**
+     * @param {any} appName
+     * @returns {string}
+     * @private
+     */
+    static _parseAppName(appName) {
+        if (!appName || typeof appName !== 'string') {
+            throw new Errors.InvalidRequestError('appName is required');
+        }
+        return appName;
+    }
+
+    /**
+     * @param {any} path
+     * @param {string} name
+     * @returns {string}
+     * @private
+     */
+    static _parsePath(path, name) {
+        if (!path) {
+            throw new Errors.InvalidRequestError(`${name} is required`);
+        }
+        try {
+            if (!path || !Nimiq.ExtendedPrivateKey.isValidPath(path)) {
+                throw new Error(); // will be caught
+            }
+        } catch (error) {
+            throw new Errors.InvalidRequestError(`${name}: Invalid path`);
+        }
+        return path;
+    }
+
+    /**
+     * @param {any} paths
+     * @param {string} name
+     * @returns {string[]}
+     * @private
+     */
+    static _parsePathsArray(paths, name) {
+        if (!paths || paths.constructor !== Array) {
+            throw new Errors.InvalidRequestError(`${name} is required`);
+        }
+        /** @type {string[]} */
+        const requestedKeyPaths = [];
+        paths.forEach((/** @type {any} */path) => { // eslint-disable-line arrow-parens
+            if (typeof path !== 'string') {
+                throw new Errors.InvalidRequestError(`${name}: path must be of type string`);
+            }
+            requestedKeyPaths.push(RequestParser._parsePath(path, name));
+        });
+        return requestedKeyPaths;
+    }
+
+    /**
+     * null or string with less than 63 bytes
+     * @param {any} label
+     * @returns {string?}
+     * @private
+     */
+    static _parseLabel(label) {
+        if (!label) {
+            return '';
+        }
+        if (typeof label !== 'string') {
+            throw new Errors.InvalidRequestError('Label must be of type string');
+        }
+        return label;
+    }
+
+    /**
+     * @param {any} keyId
+     * @returns {Promise<KeyInfo>}
+     * @private
+     */
+    static async _parseKeyId(keyId) {
+        if (!keyId) {
+            throw new Errors.InvalidRequestError('keyId is required');
+        }
+        const keyInfo = await KeyStore.instance.getInfo(keyId);
+        if (!keyInfo) {
+            throw new Errors.KeyNotFoundError();
+        }
+        return keyInfo;
+    }
+}

--- a/src/lib/RequestParser.js
+++ b/src/lib/RequestParser.js
@@ -119,23 +119,13 @@ class RequestParser { // eslint-disable-line no-unused-vars
             throw new Errors.InvalidRequestError('Request must be an object');
         }
 
-        let sender;
-        try {
-            sender = new Nimiq.Address(object.sender);
-        } catch (error) {
-            throw new Errors.InvalidRequestError(`sender must be a valid Nimiq Address (${error.message})`);
-        }
+        const sender = this.parseAddress(object.sender);
         const senderType = object.senderType || Nimiq.Account.Type.BASIC;
         if (!accountTypes.has(senderType)) {
             throw new Errors.InvalidRequestError('Invalid sender type');
         }
 
-        let recipient;
-        try {
-            recipient = new Nimiq.Address(object.recipient);
-        } catch (error) {
-            throw new Errors.InvalidRequestError(`recipient must be a valid Nimiq Address (${error.message})`);
-        }
+        const recipient = this.parseAddress(object.recipient);
         const recipientType = object.recipientType || Nimiq.Account.Type.BASIC;
         if (!accountTypes.has(recipientType)) {
             throw new Errors.InvalidRequestError('Invalid sender type');
@@ -158,6 +148,19 @@ class RequestParser { // eslint-disable-line no-unused-vars
             flags,
             data,
         );
+    }
+
+    /**
+     * @param {any} address
+     * @returns {Nimiq.Address}
+     */
+    parseAddress(address) {
+        try {
+            const nqAddress = new Nimiq.Address(address);
+            return nqAddress;
+        } catch (error) {
+            throw new Errors.InvalidRequestError(`recipient must be a valid Nimiq Address (${error.message})`);
+        }
     }
 
     /**

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -28,8 +28,9 @@
  *  runKeyguard(SignTransactionApi);
  * ```
  */
-class TopLevelApi { // eslint-disable-line no-unused-vars
+class TopLevelApi extends RequestParser { // eslint-disable-line no-unused-vars
     constructor() {
+        super();
         if (window.self !== window.top) {
             // TopLevelApi may not run in a frame
             throw new Error('Illegal use');

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -3,6 +3,7 @@
 /* global CookieJar */
 /* global I18n */
 /* global ErrorConstants */
+/* global RequestParser */
 
 /**
  * A common parent class for pop-up requests.

--- a/src/request/change-passphrase/ChangePassphraseApi.js
+++ b/src/request/change-passphrase/ChangePassphraseApi.js
@@ -9,7 +9,7 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
      * @param {KeyguardRequest.SimpleRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RequestParser.parse(request, 'SimpleRequest');
+        const parsedRequest = await this.parseRequest(request);
         const handler = new ChangePassphrase(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -24,5 +24,23 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
 
         // Async pre-load the crypto worker to reduce wait time at first decrypt attempt
         Nimiq.CryptoWorker.getInstanceAsync();
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.SimpleRequest} request
+     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
+     */
+    async parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.keyInfo = await this.parseKeyId(request.keyId);
+        parsedRequest.keyLabel = this.parseLabel(request.keyLabel);
+
+        return parsedRequest;
     }
 }

--- a/src/request/change-passphrase/ChangePassphraseApi.js
+++ b/src/request/change-passphrase/ChangePassphraseApi.js
@@ -26,7 +26,6 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
     }
 
     /**
-     *
      * @param {KeyguardRequest.SimpleRequest} request
      * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
      */

--- a/src/request/change-passphrase/ChangePassphraseApi.js
+++ b/src/request/change-passphrase/ChangePassphraseApi.js
@@ -1,7 +1,7 @@
 /* global Nimiq */
 /* global TopLevelApi */
 /* global ChangePassphrase */
-/* global KeyStore */
+/* global RequestParser */
 /* global Errors */
 
 class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -9,7 +9,7 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
      * @param {KeyguardRequest.SimpleRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await ChangePassphraseApi._parseRequest(request);
+        const parsedRequest = await RequestParser.parse(request, 'SimpleRequest');
         const handler = new ChangePassphrase(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -24,43 +24,5 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
 
         // Async pre-load the crypto worker to reduce wait time at first decrypt attempt
         Nimiq.CryptoWorker.getInstanceAsync();
-    }
-
-    /**
-     * @param {KeyguardRequest.SimpleRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
-     * @private
-     */
-    static async _parseRequest(request) {
-        if (!request) {
-            throw new Errors.InvalidRequestError('Request can not be empty');
-        }
-
-        // Check that keyId is given.
-        if (!request.keyId || typeof request.keyId !== 'string') {
-            throw new Errors.InvalidRequestError('keyId is required');
-        }
-
-        // Check that appName is given
-        if (!request.appName || typeof request.appName !== 'string') {
-            throw new Errors.InvalidRequestError('appName is required');
-        }
-
-        // Check that key exists.
-        const keyInfo = await KeyStore.instance.getInfo(request.keyId);
-        if (!keyInfo) {
-            throw new Errors.KeyNotFoundError();
-        }
-
-        // Validate labels.
-        if (request.keyLabel !== undefined && (typeof request.keyLabel !== 'string' || request.keyLabel.length > 64)) {
-            throw new Errors.InvalidRequestError('Invalid keyLabel');
-        }
-
-        return /** @type {ParsedSimpleRequest} */ {
-            appName: request.appName,
-            keyInfo,
-            keyLabel: request.keyLabel,
-        };
     }
 }

--- a/src/request/change-passphrase/ChangePassphraseApi.js
+++ b/src/request/change-passphrase/ChangePassphraseApi.js
@@ -1,7 +1,6 @@
 /* global Nimiq */
 /* global TopLevelApi */
 /* global ChangePassphrase */
-/* global RequestParser */
 /* global Errors */
 
 class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -32,8 +31,8 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
      * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
      */
     async parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};

--- a/src/request/change-passphrase/index.html
+++ b/src/request/change-passphrase/index.html
@@ -16,6 +16,7 @@
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
     <script defer bundle-common src="../../lib/CookieJar.js"></script>

--- a/src/request/change-passphrase/index.html
+++ b/src/request/change-passphrase/index.html
@@ -16,7 +16,6 @@
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
     <script defer bundle-common src="../../lib/CookieJar.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>

--- a/src/request/change-passphrase/index.html
+++ b/src/request/change-passphrase/index.html
@@ -23,13 +23,13 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/create/CreateApi.js
+++ b/src/request/create/CreateApi.js
@@ -22,7 +22,6 @@ class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     }
 
     /**
-     *
      * @param {KeyguardRequest.CreateRequest} request
      * @returns {KeyguardRequest.CreateRequest}
      */

--- a/src/request/create/CreateApi.js
+++ b/src/request/create/CreateApi.js
@@ -1,14 +1,14 @@
 /* global TopLevelApi */
 /* global Create */
-/* global Nimiq */
 /* global Errors */
+/* global RequestParser */
 
 class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.CreateRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = CreateApi._parseRequest(request);
+        const parsedRequest = await RequestParser.parse(request, 'CreateRequest');
         const handler = new Create(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -20,26 +20,5 @@ class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         handler.run();
-    }
-
-    /**
-     * @param {KeyguardRequest.CreateRequest} request
-     * @returns {KeyguardRequest.CreateRequest}
-     * @private
-     */
-    static _parseRequest(request) {
-        if (!request) {
-            throw new Errors.InvalidRequestError('Empty request');
-        }
-
-        if (!request.appName || typeof request.appName !== 'string') {
-            throw new Errors.InvalidRequestError('appName is required');
-        }
-
-        if (!request.defaultKeyPath || !Nimiq.ExtendedPrivateKey.isValidPath(request.defaultKeyPath)) {
-            throw new Errors.InvalidRequestError('Invalid defaultKeyPath');
-        }
-
-        return request;
     }
 }

--- a/src/request/create/CreateApi.js
+++ b/src/request/create/CreateApi.js
@@ -1,7 +1,6 @@
 /* global TopLevelApi */
 /* global Create */
 /* global Errors */
-/* global RequestParser */
 
 class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
@@ -28,13 +27,13 @@ class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @returns {KeyguardRequest.CreateRequest}
      */
     parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};
         parsedRequest.appName = this.parseAppName(request.appName);
-        parsedRequest.defaultKeyPath = this.parsePath(request.defaultKeyPath, "defaultKeyPath");
+        parsedRequest.defaultKeyPath = this.parsePath(request.defaultKeyPath, 'defaultKeyPath');
 
         return parsedRequest;
     }

--- a/src/request/create/CreateApi.js
+++ b/src/request/create/CreateApi.js
@@ -8,7 +8,7 @@ class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @param {KeyguardRequest.CreateRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RequestParser.parse(request, 'CreateRequest');
+        const parsedRequest = this.parseRequest(request);
         const handler = new Create(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -20,5 +20,22 @@ class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         handler.run();
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.CreateRequest} request
+     * @returns {KeyguardRequest.CreateRequest}
+     */
+    parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.defaultKeyPath = this.parsePath(request.defaultKeyPath, "defaultKeyPath");
+
+        return parsedRequest;
     }
 }

--- a/src/request/create/index.html
+++ b/src/request/create/index.html
@@ -16,6 +16,7 @@
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
     <script defer bundle-common src="../../lib/CookieJar.js"></script>

--- a/src/request/create/index.html
+++ b/src/request/create/index.html
@@ -16,7 +16,6 @@
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
     <script defer bundle-common src="../../lib/CookieJar.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>

--- a/src/request/create/index.html
+++ b/src/request/create/index.html
@@ -23,12 +23,12 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -1,8 +1,6 @@
 /* global TopLevelApi */
 /* global DeriveAddress */
-/* global Key */
-/* global KeyStore */
-/* global Nimiq */
+/* global RequestParser */
 /* global Errors */
 
 class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -10,7 +8,7 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
      * @param {KeyguardRequest.DeriveAddressRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await DeriveAddressApi._parseRequest(request);
+        const parsedRequest = await RequestParser.parse(request, 'DeriveAddressRequest');
         const handler = new DeriveAddress(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -22,50 +20,5 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         handler.run();
-    }
-
-    /**
-     * @param {KeyguardRequest.DeriveAddressRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedDeriveAddressRequest>}
-     * @private
-     */
-    static async _parseRequest(request) {
-        if (!request) {
-            throw new Errors.InvalidRequestError('Empty request');
-        }
-
-        if (!request.appName || typeof request.appName !== 'string') {
-            throw new Errors.InvalidRequestError('appName is required');
-        }
-
-        if (!request.keyId || typeof request.keyId !== 'string') {
-            throw new Errors.InvalidRequestError('keyId is required');
-        }
-
-        // Check that key exists.
-        const keyInfo = await KeyStore.instance.getInfo(request.keyId);
-        if (!keyInfo) {
-            throw new Errors.KeyNotFoundError();
-        }
-
-        if (keyInfo.type === Key.Type.LEGACY) {
-            throw new Errors.InvalidRequestError('Cannot derive addresses for single-account wallets');
-        }
-
-        if (!request.baseKeyPath || !Nimiq.ExtendedPrivateKey.isValidPath(request.baseKeyPath)) {
-            throw new Errors.InvalidRequestError('Invalid baseKeyPath');
-        }
-
-        if (!request.indicesToDerive || !(request.indicesToDerive instanceof Array)) {
-            throw new Errors.InvalidRequestError('Invalid indicesToDerive');
-        }
-
-        return {
-            appName: request.appName,
-            keyInfo,
-            keyLabel: request.keyLabel,
-            baseKeyPath: request.baseKeyPath,
-            indicesToDerive: request.indicesToDerive,
-        };
     }
 }

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -8,7 +8,7 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
      * @param {KeyguardRequest.DeriveAddressRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RequestParser.parse(request, 'DeriveAddressRequest');
+        const parsedRequest = await this.parseRequest(request);
         const handler = new DeriveAddress(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -20,5 +20,28 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         handler.run();
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.DeriveAddressRequest} request
+     * @returns {Promise<KeyguardRequest.ParsedDeriveAddressRequest>}
+     */
+    async parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.keyInfo = await this.parseKeyId(request.keyId);
+        if (parsedRequest.keyInfo.type === Key.Type.LEGACY) {
+            throw new Errors.InvalidRequestError('Cannot derive addresses for single-account wallets');
+        }
+        parsedRequest.keyLabel = this.parseLabel(request.keyLabel);
+        parsedRequest.baseKeyPath = this.parsePath(request.baseKeyPath, 'baseKeyPath');
+        parsedRequest.indicesToDerive = this.parseIndicesArray(request.indicesToDerive);
+
+        return parsedRequest;
     }
 }

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -1,7 +1,7 @@
 /* global TopLevelApi */
 /* global DeriveAddress */
-/* global RequestParser */
 /* global Errors */
+/* global Key */
 
 class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
@@ -28,8 +28,8 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
      * @returns {Promise<KeyguardRequest.ParsedDeriveAddressRequest>}
      */
     async parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -1,7 +1,7 @@
 /* global TopLevelApi */
 /* global DeriveAddress */
-/* global Errors */
 /* global Key */
+/* global Errors */
 
 class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
@@ -23,7 +23,6 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
     }
 
     /**
-     *
      * @param {KeyguardRequest.DeriveAddressRequest} request
      * @returns {Promise<KeyguardRequest.ParsedDeriveAddressRequest>}
      */

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -15,7 +15,6 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -15,6 +15,7 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -23,13 +23,13 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -22,7 +22,6 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     }
 
     /**
-     *
      * @param {KeyguardRequest.SimpleRequest} request
      * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
      */

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -1,6 +1,6 @@
 /* global TopLevelApi */
 /* global Export */
-/* global KeyStore */
+/* global RequestParser */
 /* global Errors */
 
 class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -8,7 +8,7 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @param {KeyguardRequest.SimpleRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await ExportApi._parseRequest(request);
+        const parsedRequest = await RequestParser.parse(request, 'SimpleRequest');
         const exportHandler = new Export(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -20,37 +20,5 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         exportHandler.run();
-    }
-
-    /**
-     * @param {KeyguardRequest.SimpleRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
-     */
-    static async _parseRequest(request) {
-        if (!request) {
-            throw new Errors.InvalidRequestError('Empty request');
-        }
-
-        // Check that keyId is given.
-        if (typeof request.keyId !== 'string' || !request.keyId) {
-            throw new Errors.InvalidRequestError('keyId is required');
-        }
-
-        // Check that key exists.
-        const keyInfo = await KeyStore.instance.getInfo(request.keyId);
-        if (!keyInfo) {
-            throw new Errors.KeyNotFoundError();
-        }
-
-        // Validate labels.
-        if (request.keyLabel !== undefined && (typeof request.keyLabel !== 'string' || request.keyLabel.length > 64)) {
-            throw new Errors.InvalidRequestError('Invalid label');
-        }
-
-        return /** @type {ParsedSimpleRequest} */ {
-            appName: request.appName,
-            keyInfo,
-            keyLabel: request.keyLabel,
-        };
     }
 }

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -8,7 +8,7 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @param {KeyguardRequest.SimpleRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RequestParser.parse(request, 'SimpleRequest');
+        const parsedRequest = await this.parseRequest(request);
         const exportHandler = new Export(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -20,5 +20,23 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         exportHandler.run();
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.SimpleRequest} request
+     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
+     */
+    async parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.keyInfo = await this.parseKeyId(request.keyId);
+        parsedRequest.keyLabel = this.parseLabel(request.keyLabel);
+
+        return parsedRequest;
     }
 }

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -1,6 +1,5 @@
 /* global TopLevelApi */
 /* global Export */
-/* global RequestParser */
 /* global Errors */
 
 class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -28,8 +27,8 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
      */
     async parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -15,7 +15,6 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -15,6 +15,7 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -23,13 +23,13 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -8,7 +8,6 @@
 /* global KeyStore */
 /* global Errors */
 /* global Utf8Tools */
-/* global RequestParser */
 
 class ImportApi extends TopLevelApi {
     constructor() {
@@ -255,13 +254,13 @@ class ImportApi extends TopLevelApi {
      * @returns {KeyguardRequest.ImportRequest}
      */
     parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};
         parsedRequest.appName = this.parseAppName(request.appName);
-        parsedRequest.defaultKeyPath = this.parsePath(request.defaultKeyPath, "defaultKeyPath");
+        parsedRequest.defaultKeyPath = this.parsePath(request.defaultKeyPath, 'defaultKeyPath');
         parsedRequest.requestedKeyPaths = this.parsePathsArray(request.requestedKeyPaths, ' requestKeyPaths');
 
         return parsedRequest;

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -8,6 +8,7 @@
 /* global KeyStore */
 /* global Errors */
 /* global Utf8Tools */
+/* global RequestParser */
 
 class ImportApi extends TopLevelApi {
     constructor() {
@@ -27,7 +28,7 @@ class ImportApi extends TopLevelApi {
      * @param {KeyguardRequest.ImportRequest} request
      */
     async onRequest(request) {
-        this._request = request;
+        this._request = await RequestParser.parse(request, 'ImportRequest');
 
         // Global cancel link
         /** @type {HTMLElement} */

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -28,7 +28,7 @@ class ImportApi extends TopLevelApi {
      * @param {KeyguardRequest.ImportRequest} request
      */
     async onRequest(request) {
-        this._request = await RequestParser.parse(request, 'ImportRequest');
+        this._request = this.parseRequest(request);
 
         // Global cancel link
         /** @type {HTMLElement} */
@@ -247,6 +247,24 @@ class ImportApi extends TopLevelApi {
         this._passphraseSetterBox.reset();
         window.location.hash = ImportApi.Pages.SET_PASSPHRASE;
         this._passphraseSetterBox.focus();
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.ImportRequest} request
+     * @returns {KeyguardRequest.ImportRequest}
+     */
+    parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.defaultKeyPath = this.parsePath(request.defaultKeyPath, "defaultKeyPath");
+        parsedRequest.requestedKeyPaths = this.parsePathsArray(request.requestedKeyPaths, ' requestKeyPaths');
+
+        return parsedRequest;
     }
 }
 

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -249,7 +249,6 @@ class ImportApi extends TopLevelApi {
     }
 
     /**
-     *
      * @param {KeyguardRequest.ImportRequest} request
      * @returns {KeyguardRequest.ImportRequest}
      */

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -15,7 +15,6 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -15,6 +15,7 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -23,13 +23,13 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -1,6 +1,6 @@
 /* global TopLevelApi */
 /* global RemoveKey */
-/* global KeyStore */
+/* global RequestParser */
 /* global Errors */
 
 class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -8,7 +8,7 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @param {KeyguardRequest.SimpleRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RemoveKeyApi._parseRequest(request);
+        const parsedRequest = await RequestParser.parse(request, 'SimpleRequest');
         const removeKeyHandler = new RemoveKey(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -20,38 +20,5 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         removeKeyHandler.run();
-    }
-
-    /**
-     * @param {KeyguardRequest.SimpleRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
-     * @private
-     */
-    static async _parseRequest(request) {
-        if (!request) {
-            throw new Errors.InvalidRequestError('Empty request');
-        }
-
-        // Check that keyId is given.
-        if (!request.keyId || typeof request.keyId !== 'string') {
-            throw new Errors.InvalidRequestError('keyId is required');
-        }
-
-        // Check that key exists.
-        const keyInfo = await KeyStore.instance.getInfo(request.keyId);
-        if (!keyInfo) {
-            throw new Errors.KeyNotFoundError();
-        }
-
-        // Validate labels.
-        if (request.keyLabel !== undefined && (typeof request.keyLabel !== 'string' || request.keyLabel.length > 64)) {
-            throw new Errors.InvalidRequestError('Invalid label');
-        }
-
-        return /** @type {ParsedRemoveKeyRequest} */ {
-            appName: request.appName,
-            keyInfo,
-            keyLabel: request.keyLabel,
-        };
     }
 }

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -22,7 +22,6 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     }
 
     /**
-     *
      * @param {KeyguardRequest.SimpleRequest} request
      * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
      */

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -1,6 +1,5 @@
 /* global TopLevelApi */
 /* global RemoveKey */
-/* global RequestParser */
 /* global Errors */
 
 class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -28,8 +27,8 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
      */
     async parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -8,7 +8,7 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @param {KeyguardRequest.SimpleRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RequestParser.parse(request, 'SimpleRequest');
+        const parsedRequest = await this.parseRequest(request);
         const removeKeyHandler = new RemoveKey(parsedRequest, this.resolve.bind(this), this.reject.bind(this));
 
         /** @type {HTMLElement} */
@@ -20,5 +20,23 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         removeKeyHandler.run();
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.SimpleRequest} request
+     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
+     */
+    async parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.keyInfo = await this.parseKeyId(request.keyId);
+        parsedRequest.keyLabel = this.parseLabel(request.keyLabel);
+
+        return parsedRequest;
     }
 }

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -15,7 +15,6 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -15,6 +15,7 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -23,13 +23,13 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -1,7 +1,6 @@
 /* global TopLevelApi */
 /* global SignMessage */
 /* global Errors */
-/* global Nimiq */
 
 class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
@@ -31,7 +30,6 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     }
 
     /**
-     *
      * @param {KeyguardRequest.SignMessageRequest} request
      * @returns {Promise<KeyguardRequest.ParsedSignMessageRequest>}
      */
@@ -47,11 +45,7 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         parsedRequest.keyPath = this.parsePath(request.keyPath, 'keyPath');
         parsedRequest.message = this.parseMessage(request.message);
         parsedRequest.signerLabel = this.parseLabel(request.signerLabel);
-        try {
-            parsedRequest.signer = new Nimiq.Address(request.signer);
-        } catch (error) {
-            throw new Errors.InvalidRequestError(`Signer must be a valid Nimiq Address (${error.message})`);
-        }
+        parsedRequest.signer = this.parseAddress(request.signer);
 
         return parsedRequest;
     }

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -1,7 +1,7 @@
-/* global RequestParser */
 /* global TopLevelApi */
 /* global SignMessage */
 /* global Errors */
+/* global Nimiq */
 
 class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
@@ -36,8 +36,8 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @returns {Promise<KeyguardRequest.ParsedSignMessageRequest>}
      */
     async parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -8,7 +8,7 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @param {KeyguardRequest.SignMessageRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RequestParser.parse(request, 'SignMessageRequest');
+        const parsedRequest = await this.parseRequest(request);
         /** @type {HTMLDivElement} */
         const $page = (document.getElementById(SignMessage.Pages.AUTHORIZE));
 
@@ -28,5 +28,31 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         handler.run();
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.SignMessageRequest} request
+     * @returns {Promise<KeyguardRequest.ParsedSignMessageRequest>}
+     */
+    async parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.keyInfo = await this.parseKeyId(request.keyId);
+        parsedRequest.keyLabel = this.parseLabel(request.keyLabel);
+        parsedRequest.keyPath = this.parsePath(request.keyPath, 'keyPath');
+        parsedRequest.message = this.parseMessage(request.message);
+        parsedRequest.signerLabel = this.parseLabel(request.signerLabel);
+        try {
+            parsedRequest.signer = new Nimiq.Address(request.signer);
+        } catch (error) {
+            throw new Errors.InvalidRequestError(`Signer must be a valid Nimiq Address (${error.message})`);
+        }
+
+        return parsedRequest;
     }
 }

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -1,8 +1,6 @@
-/* global Nimiq */
-/* global KeyStore */
+/* global RequestParser */
 /* global TopLevelApi */
 /* global SignMessage */
-/* global Utf8Tools */
 /* global Errors */
 
 class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
@@ -10,7 +8,7 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
      * @param {KeyguardRequest.SignMessageRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await SignMessageApi._parseRequest(request);
+        const parsedRequest = await RequestParser.parse(request, 'SignMessageRequest');
         /** @type {HTMLDivElement} */
         const $page = (document.getElementById(SignMessage.Pages.AUTHORIZE));
 
@@ -30,73 +28,5 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         $cancelLink.addEventListener('click', () => this.reject(new Errors.RequestCanceled()));
 
         handler.run();
-    }
-
-    /**
-     * @param {KeyguardRequest.SignMessageRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSignMessageRequest>}
-     * @private
-     */
-    static async _parseRequest(request) {
-        if (!request) {
-            throw new Errors.InvalidRequestError('Empty request');
-        }
-
-        // Check that keyId is given.
-        if (!request.keyId || typeof request.keyId !== 'string') {
-            throw new Errors.InvalidRequestError('keyId is required');
-        }
-
-        // Check that key exists.
-        const keyInfo = await KeyStore.instance.getInfo(request.keyId);
-        if (!keyInfo) {
-            throw new Errors.KeyNotFoundError();
-        }
-
-        // Check that keyPath is given.
-        if (!request.keyPath || typeof request.keyPath !== 'string') {
-            throw new Errors.InvalidRequestError('keyPath is required');
-        }
-
-        // Check that keyPath is valid.
-        if (!Nimiq.ExtendedPrivateKey.isValidPath(request.keyPath)) {
-            throw new Errors.InvalidRequestError('Invalid keyPath');
-        }
-
-        // Parse and validate message.
-        const message = SignMessageApi._parseMessage(request.message);
-        if (message.length > 255) {
-            throw new Errors.InvalidRequestError('Message must not exceed 255 bytes');
-        }
-
-        // Validate signer address
-        const address = new Nimiq.Address(request.signer);
-
-        // Validate labels.
-        const labels = [request.keyLabel, request.signerLabel];
-        if (labels.some(label => label !== undefined && (typeof label !== 'string' || label.length > 64))) {
-            throw new Errors.InvalidRequestError('Invalid label');
-        }
-
-        return /** @type {ParsedSignMessageRequest} */ {
-            appName: request.appName,
-            keyInfo,
-            keyPath: request.keyPath,
-            keyLabel: request.keyLabel,
-            signer: address,
-            signerLabel: request.signerLabel,
-            message,
-        };
-    }
-
-    /**
-     * @param {Uint8Array | string} message
-     * @returns {Uint8Array}
-     * @private
-     */
-    static _parseMessage(message) {
-        if (message instanceof Uint8Array) return message;
-        if (typeof message === 'string') return Utf8Tools.stringToUtf8ByteArray(message);
-        throw new Errors.InvalidRequestError('Type of message must be a String or Uint8Array');
     }
 }

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -45,7 +45,7 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         parsedRequest.keyPath = this.parsePath(request.keyPath, 'keyPath');
         parsedRequest.message = this.parseMessage(request.message);
         parsedRequest.signerLabel = this.parseLabel(request.signerLabel);
-        parsedRequest.signer = this.parseAddress(request.signer);
+        parsedRequest.signer = this.parseAddress(request.signer, 'signer');
 
         return parsedRequest;
     }

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -15,7 +15,6 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -15,6 +15,7 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -23,13 +23,13 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -10,13 +10,7 @@ class SignTransactionApi extends TopLevelApi {
      * @param {KeyguardRequest.SignTransactionRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await RequestParser.parse(
-            request,
-            'SignTransactionRequest',
-            SignTransactionApi._parselayout.bind(this),
-        );
-        console.log(parsedRequest);
-
+        const parsedRequest = await this.parseRequest(request);
         const $layoutContainer = document.getElementById('layout-container');
 
         const handler = new SignTransactionApi.Layouts[parsedRequest.layout](
@@ -46,14 +40,41 @@ class SignTransactionApi extends TopLevelApi {
     /**
      * Checks that the given layout is valid
      * @param {any} layout
-     * @returns {string}
-     * @private
+     * @returns {any}
      */
-    static _parselayout(layout) {
+    parseLayout(layout) {
         if (layout && !SignTransactionApi.Layouts[layout]) {
             throw new Errors.InvalidRequestError('Invalid selected layout');
         }
         return layout;
+    }
+
+    /**
+     *
+     * @param {KeyguardRequest.SignTransactionRequest} request
+     * @returns {Promise<KeyguardRequest.ParsedSignTransactionRequest>}
+     */
+    async parseRequest(request) {
+        if(!request) {
+            throw new Errors.InvalidRequestError('request is required')
+        }
+
+        const parsedRequest = {};
+        parsedRequest.appName = this.parseAppName(request.appName);
+        parsedRequest.keyInfo = await this.parseKeyId(request.keyId);
+        parsedRequest.keyLabel = this.parseLabel(request.keyLabel);
+        parsedRequest.keyPath = this.parsePath(request.keyPath, 'keyPath');
+        parsedRequest.senderLabel = this.parseLabel(request.senderLabel);
+        parsedRequest.recipientLabel = this.parseLabel(request.recipientLabel);
+        parsedRequest.transaction = this.parseTransaction(request);
+        parsedRequest.layout = this.parseLayout(request.layout);
+        if (parsedRequest.layout === 'checkout') {
+            parsedRequest.shopOrigin = this.parseShopOrigin(request.shopOrigin);
+        } else {
+            parsedRequest.shopOrigin = undefined;
+        }
+
+        return parsedRequest;
     }
 }
 

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -42,14 +42,16 @@ class SignTransactionApi extends TopLevelApi {
      * @returns {any}
      */
     parseLayout(layout) {
-        if (layout && !SignTransactionApi.Layouts[layout]) {
+        if (!layout) {
+            return SignTransactionApi.Layouts.standard;
+        }
+        if (!SignTransactionApi.Layouts[layout]) {
             throw new Errors.InvalidRequestError('Invalid selected layout');
         }
         return layout;
     }
 
     /**
-     *
      * @param {KeyguardRequest.SignTransactionRequest} request
      * @returns {Promise<KeyguardRequest.ParsedSignTransactionRequest>}
      */

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -1,5 +1,4 @@
-/* global Nimiq */
-/* global KeyStore */
+/* global RequestParser */
 /* global I18n */
 /* global TopLevelApi */
 /* global LayoutStandard */
@@ -11,7 +10,13 @@ class SignTransactionApi extends TopLevelApi {
      * @param {KeyguardRequest.SignTransactionRequest} request
      */
     async onRequest(request) {
-        const parsedRequest = await SignTransactionApi._parseRequest(request);
+        const parsedRequest = await RequestParser.parse(
+            request,
+            'SignTransactionRequest',
+            SignTransactionApi._parselayout.bind(this),
+        );
+        console.log(parsedRequest);
+
         const $layoutContainer = document.getElementById('layout-container');
 
         const handler = new SignTransactionApi.Layouts[parsedRequest.layout](
@@ -39,107 +44,16 @@ class SignTransactionApi extends TopLevelApi {
     }
 
     /**
-     * @param {KeyguardRequest.SignTransactionRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSignTransactionRequest>}
+     * Checks that the given layout is valid
+     * @param {any} layout
+     * @returns {string}
      * @private
      */
-    static async _parseRequest(request) {
-        if (!request) {
-            throw new Errors.InvalidRequestError('Empty request');
-        }
-
-        // Check that the layout is valid
-        if (request.layout && !SignTransactionApi.Layouts[request.layout]) {
+    static _parselayout(layout) {
+        if (layout && !SignTransactionApi.Layouts[layout]) {
             throw new Errors.InvalidRequestError('Invalid selected layout');
         }
-
-        // Check that keyId is given.
-        if (!request.keyId || typeof request.keyId !== 'string') {
-            throw new Errors.InvalidRequestError('keyId is required');
-        }
-
-        // Check that key exists.
-        const keyInfo = await KeyStore.instance.getInfo(request.keyId);
-        if (!keyInfo) {
-            throw new Errors.KeyNotFoundError();
-        }
-
-        // Check that keyPath is given.
-        if (!request.keyPath || typeof request.keyPath !== 'string') {
-            throw new Errors.InvalidRequestError('keyPath is required');
-        }
-
-        // Check that keyPath is valid.
-        if (!Nimiq.ExtendedPrivateKey.isValidPath(request.keyPath)) {
-            throw new Errors.InvalidRequestError('Invalid keyPath');
-        }
-
-        // Parse transaction.
-        const transaction = SignTransactionApi._parseTransaction(request);
-
-        // Check that the transaction is for the correct network.
-        if (transaction.networkId !== Nimiq.GenesisConfig.NETWORK_ID) {
-            throw new Errors.InvalidRequestError('Transaction is not valid in this network');
-        }
-
-        // Check that sender != recipient.
-        if (transaction.recipient.equals(transaction.sender)) {
-            throw new Errors.InvalidRequestError('Sender and recipient must not match');
-        }
-
-        // Check sender / recipient account type.
-        const accountTypes = new Set([Nimiq.Account.Type.BASIC, Nimiq.Account.Type.VESTING, Nimiq.Account.Type.HTLC]);
-        if (!accountTypes.has(transaction.senderType) || !accountTypes.has(transaction.recipientType)) {
-            throw new Errors.InvalidRequestError('Invalid sender type');
-        }
-
-        // Validate labels.
-        const labels = [request.keyLabel, request.senderLabel, request.recipientLabel];
-        if (labels.some(label => label !== undefined && (typeof label !== 'string' || label.length > 64))) {
-            throw new Errors.InvalidRequestError('Invalid label');
-        }
-
-        return /** @type {ParsedSignTransactionRequest} */ {
-            layout: request.layout || 'standard',
-            shopOrigin: request.shopOrigin,
-            appName: request.appName,
-
-            keyInfo,
-            keyPath: request.keyPath,
-            transaction,
-
-            keyLabel: request.keyLabel,
-            senderLabel: request.senderLabel,
-            recipientLabel: request.recipientLabel,
-        };
-    }
-
-    /**
-     * @param {KeyguardRequest.SignTransactionRequest} request
-     * @returns {Nimiq.ExtendedTransaction}
-     * @private
-     */
-    static _parseTransaction(request) {
-        const sender = new Nimiq.Address(request.sender);
-        const senderType = request.senderType || Nimiq.Account.Type.BASIC;
-        const recipient = new Nimiq.Address(request.recipient);
-        const recipientType = request.recipientType || Nimiq.Account.Type.BASIC;
-        const flags = request.flags || Nimiq.Transaction.Flag.NONE;
-        const data = request.data || new Uint8Array(0);
-        const networkId = request.networkId || Nimiq.GenesisConfig.NETWORK_ID;
-        return new Nimiq.ExtendedTransaction(
-            sender,
-            senderType,
-            recipient,
-            recipientType,
-            request.value,
-            request.fee,
-            request.validityStartHeight,
-            flags,
-            data,
-            new Uint8Array(0), // proof
-            networkId,
-        );
+        return layout;
     }
 }
 

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -1,4 +1,3 @@
-/* global RequestParser */
 /* global I18n */
 /* global TopLevelApi */
 /* global LayoutStandard */
@@ -55,8 +54,8 @@ class SignTransactionApi extends TopLevelApi {
      * @returns {Promise<KeyguardRequest.ParsedSignTransactionRequest>}
      */
     async parseRequest(request) {
-        if(!request) {
-            throw new Errors.InvalidRequestError('request is required')
+        if (!request) {
+            throw new Errors.InvalidRequestError('request is required');
         }
 
         const parsedRequest = {};

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -15,7 +15,6 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
-    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>
@@ -24,6 +23,7 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -15,6 +15,7 @@
     <script defer src="https://cdn.nimiq-testnet.com/web-offline.js"></script>
 
     <script defer bundle-common src="../../lib/RpcServer.es.js"></script>
+    <script defer bundle-common src="../../lib/RequestParser.js"></script>
     <script defer bundle-common src="../../lib/KeyStore.js"></script>
     <script defer bundle-common src="../../lib/Key.js"></script>
     <script defer bundle-common src="../../lib/KeyInfo.js"></script>

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -23,13 +23,13 @@
     <script defer bundle-common src="../../lib/AccountStore.js"></script>
     <script defer bundle-common src="../../common.js"></script>
 
-    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseBox.js"></script>
     <script defer bundle-toplevel src="../../components/PassphraseInput.js"></script>
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/ErrorConstants.js"></script>
     <script defer bundle-toplevel src="../../lib/Errors.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
+    <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/tests/lib/RequestParser.spec.js
+++ b/tests/lib/RequestParser.spec.js
@@ -4,155 +4,116 @@
 /* global Errors */
 
 describe('RequestParser', () => {
-    beforeEach(async () => Dummy.Utils.createDummyKeyStore());
-    afterEach(async () => Dummy.Utils.deleteDummyKeyStore());
-
     it('can parse appName', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let appName = undefined;
-        expect( () => { requestParser.parseAppName(appName); }).toThrow();
-        appName = 5;
-        expect( () => { requestParser.parseAppName(appName); }).toThrow();
-        appName = { appName: 'Ein Test' };
-        expect( () => { requestParser.parseAppName(appName); }).toThrow();
-        appName = 'Ein Test';
+        expect( () => { requestParser.parseAppName(undefined); }).toThrow();
+        expect( () => { requestParser.parseAppName(5); }).toThrow();
+        expect( () => { requestParser.parseAppName({appName: 'Ein Test'}); }).toThrow();
+        const appName = 'Ein Test';
         expect(requestParser.parseAppName(appName)).toEqual(appName);
     });
 
-    it('can parse Path', () => {
+    it('can parse path', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let path = undefined;
-        expect( () => { requestParser.parsePath(path, '1'); }).toThrow();
-        path = 5;
-        expect( () => { requestParser.parsePath(path, '2'); }).toThrow();
-        path = { path: 'Ein Test' };
-        expect( () => { requestParser.parsePath(path, '3'); }).toThrow();
-        path = 'Ein Test';
-        expect( () => { requestParser.parsePath(path, '4'); }).toThrow();
-        path = "m/44'/242'/0'/6'";
+        expect( () => { requestParser.parsePath(undefined, '1'); }).toThrow();
+        expect( () => { requestParser.parsePath(5, '2'); }).toThrow();
+        expect( () => { requestParser.parsePath({path: 'A test'}, '3'); }).toThrow();
+        expect( () => { requestParser.parsePath('A test', '4'); }).toThrow();
+        const path = "m/44'/242'/0'/6'";
         expect(requestParser.parsePath(path, '5')).toEqual(path);
     });
 
-    it('can parse Path Arrays', () => {
+    it('can parse paths arrays', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let paths = undefined;
-        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
-        paths = 5;
-        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
-        paths = { something: 5 };
-        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
-        paths = [];
-        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
-        paths = ['something'];
-        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
-        paths = ["m/44'/242'/0'/6'","m/44'/242'/0'/6'"];
+        expect( () => { requestParser.parsePathsArray(undefined, '1'); }).toThrow();
+        expect( () => { requestParser.parsePathsArray(5, '1'); }).toThrow();
+        expect( () => { requestParser.parsePathsArray({something: 5}, '1'); }).toThrow();
+        expect( () => { requestParser.parsePathsArray([], '1'); }).toThrow();
+        expect( () => { requestParser.parsePathsArray(['something'], '1'); }).toThrow();
+        const paths = ["m/44'/242'/0'/6'","m/44'/242'/0'/6'"];
         expect(requestParser.parsePathsArray(paths, '1')).toEqual(paths);
     });
 
     it('can parse label', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let label = undefined;
-        expect(requestParser.parseLabel(label)).toBe(undefined);
-        label = 5;
-        expect( () => { requestParser.parseLabel(label); }).toThrow();
-        label = '';
-        expect( requestParser.parseLabel(label)).toBe(undefined);
-        label = {};
-        expect( () => { requestParser.parseLabel(label); }).toThrow();
-        label = 'Ein Test';
+        expect(requestParser.parseLabel(undefined)).toBe(undefined);
+        expect( () => { requestParser.parseLabel(5); }).toThrow();
+        expect( requestParser.parseLabel('')).toBe(undefined);
+        expect( () => { requestParser.parseLabel({}); }).toThrow();
+        const label = 'Ein Test';
         expect(requestParser.parseLabel(label)).toEqual(label);
     });
 
-    it('can parse KeyId to keyInfo', async () => {
+    it('can parse keyId to keyInfo', async () => {
+        Dummy.Utils.createDummyKeyStore();
         const requestParser = new RequestParser();
         let error;
 
-        /** @type {any} */
-        let keyId = undefined;
         try {
-            const x = await requestParser.parseKeyId(keyId);
+            const x = await requestParser.parseKeyId(undefined);
         } catch(e) {
             error = e;
         }
-        expect(error).toEqual(new Errors.InvalidRequestError('keyId is required'));
+        expect(error).toEqual(new Errors.InvalidRequestError('keyId must be a string'));
 
-        keyId = {keyId: 75};
         try {
-            const x = await requestParser.parseKeyId(keyId);
+            const x = await requestParser.parseKeyId({keyId:75});
         } catch(e) {
             error = e;
         }
-        expect(error).toEqual(new Errors.InvalidRequestError('keyId must be of type string'));
+        expect(error).toEqual(new Errors.InvalidRequestError('keyId must be a string'));
 
-        keyId = 'SuchMalNachDieserKeyId';
         try {
-            const x = await requestParser.parseKeyId(keyId);
+            const x = await requestParser.parseKeyId('ThisIsNotAKeyId');
         } catch(e) {
             error = e;
         }
         expect(error).toEqual(new Errors.KeyNotFoundError());
 
-        keyId = 5;
         try {
-            const x = await requestParser.parseKeyId(keyId);
+            const x = await requestParser.parseKeyId(5);
         } catch(e) {
             error = e;
         }
-        expect(error).toEqual(new Errors.InvalidRequestError('keyId must be of type string'));
+        expect(error).toEqual(new Errors.InvalidRequestError('keyId must be a string'));
 
-
-        keyId = '2ec615522906'; // dummy data
-        let parsedKeyInfo = await requestParser.parseKeyId(keyId);
-        expect(new KeyInfo(
+        let parsedKeyInfo = await requestParser.parseKeyId('2ec615522906');
+        expect(parsedKeyInfo).toEqual(new KeyInfo(
             '2ec615522906',
             Key.Type.LEGACY,
             true,
             false,
-        )).toEqual(parsedKeyInfo);
+        ));
+
+        Dummy.Utils.deleteDummyKeyStore();
     });
 
-    it('can parse indiceArrays', () => {
+    it('can parse indicesArrays', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let indicesArray = undefined;
-        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
-        indicesArray = { x: 7 };
-        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
-        indicesArray = 'SindDasIndices';
-        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
-        indicesArray = 9;
-        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
-        indicesArray = [];
-        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
-        indicesArray = [1,2,3,4,5];
-        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
-        indicesArray = ["1","2","3"];
-        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
-        indicesArray = ["1'","2'","3'"];
+        expect( () => { requestParser.parseIndicesArray(undefined); }).toThrow();
+        expect( () => { requestParser.parseIndicesArray({x: 7}); }).toThrow();
+        expect( () => { requestParser.parseIndicesArray('ThisIsNotAnArray'); }).toThrow();
+        expect( () => { requestParser.parseIndicesArray(9); }).toThrow();
+        expect( () => { requestParser.parseIndicesArray([]); }).toThrow();
+        expect( () => { requestParser.parseIndicesArray([1,2,3,4,5]); }).toThrow();
+        expect( () => { requestParser.parseIndicesArray(["1","2","3"]); }).toThrow();
+        const indicesArray = ["1'","2'","3'"];
         expect(requestParser.parseIndicesArray(indicesArray)).toEqual(indicesArray);
     });
 
-    it('can parse transaction', () => {
+    it('can parse transactions', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let transaction = undefined;
-        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
-        transaction = 5;
-        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
-        transaction = {};
-        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
+        expect( () => { requestParser.parseTransaction(undefined); }).toThrow();
+        expect( () => { requestParser.parseTransaction(5); }).toThrow();
+        expect( () => { requestParser.parseTransaction({}); }).toThrow();
 
-        transaction = {
+        const transaction = {
             data: new Uint8Array([84, 104, 97, 110, 107, 32, 121, 111, 117, 32, 102, 111, 114, 32, 115, 104, 111, 112, 112, 105, 110, 103, 32, 97, 116, 32, 115, 104, 111, 112, 46, 110, 105, 109, 105, 113, 46, 99, 111, 109, 32, 40, 72, 51, 88, 67, 48, 68, 41]),
             fee: 0,
             recipient: new Uint8Array([225, 253, 0, 255, 238, 105, 158, 173, 122, 16, 27, 203, 31, 16, 3, 178, 231, 105, 81, 188]),
@@ -164,16 +125,14 @@ describe('RequestParser', () => {
         expect(requestParser.parseTransaction(transaction)).toEqual(
             new Nimiq.ExtendedTransaction(
                 new Nimiq.Address(new Uint8Array([238, 61, 13, 183, 158, 200, 247, 106, 130, 61, 9, 123, 134, 82, 60, 95, 16, 71, 39, 70])), //sender
-                0, // senderType
+                Nimiq.Account.Type.BASIC, // senderType
                 new Nimiq.Address(new Uint8Array([225, 253, 0, 255, 238, 105, 158, 173, 122, 16, 27, 203, 31, 16, 3, 178, 231, 105, 81, 188])), // recipient
-                0, //recipientType
+                Nimiq.Account.Type.BASIC, //recipientType
                 545000000, // value
                 0, // fee
                 176450, // validityStartHeight
                 0, // flags
                 new Uint8Array([84, 104, 97, 110, 107, 32, 121, 111, 117, 32, 102, 111, 114, 32, 115, 104, 111, 112, 112, 105, 110, 103, 32, 97, 116, 32, 115, 104, 111, 112, 46, 110, 105, 109, 105, 113, 46, 99, 111, 109, 32, 40, 72, 51, 88, 67, 48, 68, 41]), // data
-                new Uint8Array(0), // proof
-                1, // networkId
             ),
         );
 
@@ -188,32 +147,22 @@ describe('RequestParser', () => {
     it('can parse message', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let message = undefined;
-        expect( () => { requestParser.parseMessage(message); }).toThrow();
-        message = '123456';
-        expect(requestParser.parseMessage(message)).toEqual(new Uint8Array([49, 50, 51, 52, 53, 54]));
-        message = 5;
-        expect( () => { requestParser.parseMessage(message); }).toThrow();
-        message = {};
-        expect( () => { requestParser.parseMessage(message); }).toThrow();
-        message = new Uint8Array([238, 61, 13, 183, 158, 200, 247, 106, 130, 61, 9, 123, 134, 82, 60, 95, 16, 71, 39, 70]);
+        expect( () => { requestParser.parseMessage(undefined); }).toThrow();
+        expect( () => { requestParser.parseMessage(5); }).toThrow();
+        expect( () => { requestParser.parseMessage({}); }).toThrow();
+        expect(requestParser.parseMessage('123456')).toEqual(new Uint8Array([49, 50, 51, 52, 53, 54]));
+        const message = new Uint8Array([238, 61, 13, 183, 158, 200, 247, 106, 130, 61, 9, 123, 134, 82, 60, 95, 16, 71, 39, 70]);
         expect(requestParser.parseMessage(message)).toEqual(message);
     });
 
     it('can parse shopOrigin', () => {
         const requestParser = new RequestParser();
 
-        /** @type {any} */
-        let url = undefined;
-        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
-        url = 5;
-        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
-        url = {};
-        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
-        url = 'isThisAUrl?';
-        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
-        url = 'http://nimiq.com';
+        expect( () => { requestParser.parseShopOrigin(undefined); }).toThrow();
+        expect( () => { requestParser.parseShopOrigin(5); }).toThrow();
+        expect( () => { requestParser.parseShopOrigin({}); }).toThrow();
+        expect( () => { requestParser.parseShopOrigin('isThisAUrl?'); }).toThrow();
+        let url = 'http://nimiq.com';
         expect(requestParser.parseShopOrigin(url)).toEqual('http://nimiq.com');
         url = 'http://nimiq.com/some/path/some/where/index.html?foo=bar';
         expect(requestParser.parseShopOrigin(url)).toEqual('http://nimiq.com');

--- a/tests/lib/RequestParser.spec.js
+++ b/tests/lib/RequestParser.spec.js
@@ -4,9 +4,6 @@
 /* global Errors */
 
 describe('RequestParser', () => {
-    beforeAll(() => Dummy.Utils.createDummyKeyStore());
-    afterAll(() => Dummy.Utils.deleteDummyKeyStore());
-
     it('can parse appName', () => {
         const requestParser = new RequestParser();
 
@@ -52,6 +49,8 @@ describe('RequestParser', () => {
     });
 
     it('can parse keyId to keyInfo', async () => {
+        await Dummy.Utils.createDummyKeyStore();
+
         const requestParser = new RequestParser();
         let error;
 
@@ -90,6 +89,8 @@ describe('RequestParser', () => {
             true,
             false,
         ));
+
+        await Dummy.Utils.deleteDummyKeyStore();
     });
 
     it('can parse indicesArrays', () => {

--- a/tests/lib/RequestParser.spec.js
+++ b/tests/lib/RequestParser.spec.js
@@ -4,6 +4,9 @@
 /* global Errors */
 
 describe('RequestParser', () => {
+    beforeAll(() => Dummy.Utils.createDummyKeyStore());
+    afterAll(() => Dummy.Utils.deleteDummyKeyStore());
+
     it('can parse appName', () => {
         const requestParser = new RequestParser();
 
@@ -49,7 +52,6 @@ describe('RequestParser', () => {
     });
 
     it('can parse keyId to keyInfo', async () => {
-        Dummy.Utils.createDummyKeyStore();
         const requestParser = new RequestParser();
         let error;
 
@@ -88,8 +90,6 @@ describe('RequestParser', () => {
             true,
             false,
         ));
-
-        Dummy.Utils.deleteDummyKeyStore();
     });
 
     it('can parse indicesArrays', () => {

--- a/tests/lib/RequestParser.spec.js
+++ b/tests/lib/RequestParser.spec.js
@@ -1,0 +1,221 @@
+/* global Nimiq */
+/* global RequestParser */
+/* global Dummy */
+/* global Errors */
+
+describe('RequestParser', () => {
+    beforeEach(async () => Dummy.Utils.createDummyKeyStore());
+    afterEach(async () => Dummy.Utils.deleteDummyKeyStore());
+
+    it('can parse appName', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let appName = undefined;
+        expect( () => { requestParser.parseAppName(appName); }).toThrow();
+        appName = 5;
+        expect( () => { requestParser.parseAppName(appName); }).toThrow();
+        appName = { appName: 'Ein Test' };
+        expect( () => { requestParser.parseAppName(appName); }).toThrow();
+        appName = 'Ein Test';
+        expect(requestParser.parseAppName(appName)).toEqual(appName);
+    });
+
+    it('can parse Path', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let path = undefined;
+        expect( () => { requestParser.parsePath(path, '1'); }).toThrow();
+        path = 5;
+        expect( () => { requestParser.parsePath(path, '2'); }).toThrow();
+        path = { path: 'Ein Test' };
+        expect( () => { requestParser.parsePath(path, '3'); }).toThrow();
+        path = 'Ein Test';
+        expect( () => { requestParser.parsePath(path, '4'); }).toThrow();
+        path = "m/44'/242'/0'/6'";
+        expect(requestParser.parsePath(path, '5')).toEqual(path);
+    });
+
+    it('can parse Path Arrays', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let paths = undefined;
+        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
+        paths = 5;
+        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
+        paths = { something: 5 };
+        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
+        paths = [];
+        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
+        paths = ['something'];
+        expect( () => { requestParser.parsePathsArray(paths, '1'); }).toThrow();
+        paths = ["m/44'/242'/0'/6'","m/44'/242'/0'/6'"];
+        expect(requestParser.parsePathsArray(paths, '1')).toEqual(paths);
+    });
+
+    it('can parse label', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let label = undefined;
+        expect(requestParser.parseLabel(label)).toBe(undefined);
+        label = 5;
+        expect( () => { requestParser.parseLabel(label); }).toThrow();
+        label = '';
+        expect( requestParser.parseLabel(label)).toBe(undefined);
+        label = {};
+        expect( () => { requestParser.parseLabel(label); }).toThrow();
+        label = 'Ein Test';
+        expect(requestParser.parseLabel(label)).toEqual(label);
+    });
+
+    it('can parse KeyId to keyInfo', async () => {
+        const requestParser = new RequestParser();
+        let error;
+
+        /** @type {any} */
+        let keyId = undefined;
+        try {
+            const x = await requestParser.parseKeyId(keyId);
+        } catch(e) {
+            error = e;
+        }
+        expect(error).toEqual(new Errors.InvalidRequestError('keyId is required'));
+
+        keyId = {keyId: 75};
+        try {
+            const x = await requestParser.parseKeyId(keyId);
+        } catch(e) {
+            error = e;
+        }
+        expect(error).toEqual(new Errors.InvalidRequestError('keyId must be of type string'));
+
+        keyId = 'SuchMalNachDieserKeyId';
+        try {
+            const x = await requestParser.parseKeyId(keyId);
+        } catch(e) {
+            error = e;
+        }
+        expect(error).toEqual(new Errors.KeyNotFoundError());
+
+        keyId = 5;
+        try {
+            const x = await requestParser.parseKeyId(keyId);
+        } catch(e) {
+            error = e;
+        }
+        expect(error).toEqual(new Errors.InvalidRequestError('keyId must be of type string'));
+
+
+        keyId = '2ec615522906'; // dummy data
+        let parsedKeyInfo = await requestParser.parseKeyId(keyId);
+        expect(new KeyInfo(
+            '2ec615522906',
+            Key.Type.LEGACY,
+            true,
+            false,
+        )).toEqual(parsedKeyInfo);
+    });
+
+    it('can parse indiceArrays', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let indicesArray = undefined;
+        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
+        indicesArray = { x: 7 };
+        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
+        indicesArray = 'SindDasIndices';
+        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
+        indicesArray = 9;
+        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
+        indicesArray = [];
+        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
+        indicesArray = [1,2,3,4,5];
+        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
+        indicesArray = ["1","2","3"];
+        expect( () => { requestParser.parseIndicesArray(indicesArray); }).toThrow();
+        indicesArray = ["1'","2'","3'"];
+        expect(requestParser.parseIndicesArray(indicesArray)).toEqual(indicesArray);
+    });
+
+    it('can parse transaction', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let transaction = undefined;
+        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
+        transaction = 5;
+        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
+        transaction = {};
+        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
+
+        transaction = {
+            data: new Uint8Array([84, 104, 97, 110, 107, 32, 121, 111, 117, 32, 102, 111, 114, 32, 115, 104, 111, 112, 112, 105, 110, 103, 32, 97, 116, 32, 115, 104, 111, 112, 46, 110, 105, 109, 105, 113, 46, 99, 111, 109, 32, 40, 72, 51, 88, 67, 48, 68, 41]),
+            fee: 0,
+            recipient: new Uint8Array([225, 253, 0, 255, 238, 105, 158, 173, 122, 16, 27, 203, 31, 16, 3, 178, 231, 105, 81, 188]),
+            sender: new Uint8Array([238, 61, 13, 183, 158, 200, 247, 106, 130, 61, 9, 123, 134, 82, 60, 95, 16, 71, 39, 70]),
+            senderType: 0,
+            validityStartHeight: 176450,
+            value: 545000000,
+        };
+        expect(requestParser.parseTransaction(transaction)).toEqual(
+            new Nimiq.ExtendedTransaction(
+                new Nimiq.Address(new Uint8Array([238, 61, 13, 183, 158, 200, 247, 106, 130, 61, 9, 123, 134, 82, 60, 95, 16, 71, 39, 70])), //sender
+                0, // senderType
+                new Nimiq.Address(new Uint8Array([225, 253, 0, 255, 238, 105, 158, 173, 122, 16, 27, 203, 31, 16, 3, 178, 231, 105, 81, 188])), // recipient
+                0, //recipientType
+                545000000, // value
+                0, // fee
+                176450, // validityStartHeight
+                0, // flags
+                new Uint8Array([84, 104, 97, 110, 107, 32, 121, 111, 117, 32, 102, 111, 114, 32, 115, 104, 111, 112, 112, 105, 110, 103, 32, 97, 116, 32, 115, 104, 111, 112, 46, 110, 105, 109, 105, 113, 46, 99, 111, 109, 32, 40, 72, 51, 88, 67, 48, 68, 41]), // data
+                new Uint8Array(0), // proof
+                1, // networkId
+            ),
+        );
+
+        const sender = transaction.sender;
+        transaction.sender = transaction.recipient;
+        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
+
+        transaction.sender = sender; // in case some tests need to be added
+        // rest should be thrown (and tested) by core.
+    });
+
+    it('can parse message', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let message = undefined;
+        expect( () => { requestParser.parseMessage(message); }).toThrow();
+        message = '123456';
+        expect(requestParser.parseMessage(message)).toEqual(new Uint8Array([49, 50, 51, 52, 53, 54]));
+        message = 5;
+        expect( () => { requestParser.parseMessage(message); }).toThrow();
+        message = {};
+        expect( () => { requestParser.parseMessage(message); }).toThrow();
+        message = new Uint8Array([238, 61, 13, 183, 158, 200, 247, 106, 130, 61, 9, 123, 134, 82, 60, 95, 16, 71, 39, 70]);
+        expect(requestParser.parseMessage(message)).toEqual(message);
+    });
+
+    it('can parse shopOrigin', () => {
+        const requestParser = new RequestParser();
+
+        /** @type {any} */
+        let url = undefined;
+        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
+        url = 5;
+        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
+        url = {};
+        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
+        url = 'isThisAUrl?';
+        expect( () => { requestParser.parseShopOrigin(url); }).toThrow();
+        url = 'http://nimiq.com';
+        expect(requestParser.parseShopOrigin(url)).toEqual('http://nimiq.com');
+        url = 'http://nimiq.com/some/path/some/where/index.html?foo=bar';
+        expect(requestParser.parseShopOrigin(url)).toEqual('http://nimiq.com');
+    });
+});

--- a/tests/lib/RequestParser.spec.js
+++ b/tests/lib/RequestParser.spec.js
@@ -7,9 +7,9 @@ describe('RequestParser', () => {
     it('can parse appName', () => {
         const requestParser = new RequestParser();
 
-        expect( () => { requestParser.parseAppName(undefined); }).toThrow();
-        expect( () => { requestParser.parseAppName(5); }).toThrow();
-        expect( () => { requestParser.parseAppName({appName: 'Ein Test'}); }).toThrow();
+        expect(() => requestParser.parseAppName(undefined)).toThrow();
+        expect(() => requestParser.parseAppName(5)).toThrow();
+        expect(() => requestParser.parseAppName({appName: 'Ein Test'})).toThrow();
         const appName = 'Ein Test';
         expect(requestParser.parseAppName(appName)).toEqual(appName);
     });
@@ -17,10 +17,10 @@ describe('RequestParser', () => {
     it('can parse path', () => {
         const requestParser = new RequestParser();
 
-        expect( () => { requestParser.parsePath(undefined, '1'); }).toThrow();
-        expect( () => { requestParser.parsePath(5, '2'); }).toThrow();
-        expect( () => { requestParser.parsePath({path: 'A test'}, '3'); }).toThrow();
-        expect( () => { requestParser.parsePath('A test', '4'); }).toThrow();
+        expect(() => requestParser.parsePath(undefined, '1')).toThrow();
+        expect(() => requestParser.parsePath(5, '2')).toThrow();
+        expect(() => requestParser.parsePath({path: 'A test'}, '3')).toThrow();
+        expect(() => requestParser.parsePath('A test', '4')).toThrow();
         const path = "m/44'/242'/0'/6'";
         expect(requestParser.parsePath(path, '5')).toEqual(path);
     });
@@ -28,11 +28,11 @@ describe('RequestParser', () => {
     it('can parse paths arrays', () => {
         const requestParser = new RequestParser();
 
-        expect( () => { requestParser.parsePathsArray(undefined, '1'); }).toThrow();
-        expect( () => { requestParser.parsePathsArray(5, '1'); }).toThrow();
-        expect( () => { requestParser.parsePathsArray({something: 5}, '1'); }).toThrow();
-        expect( () => { requestParser.parsePathsArray([], '1'); }).toThrow();
-        expect( () => { requestParser.parsePathsArray(['something'], '1'); }).toThrow();
+        expect(() => requestParser.parsePathsArray(undefined, '1')).toThrow();
+        expect(() => requestParser.parsePathsArray(5, '1')).toThrow();
+        expect(() => requestParser.parsePathsArray({something: 5}, '1')).toThrow();
+        expect(() => requestParser.parsePathsArray([], '1')).toThrow();
+        expect(() => requestParser.parsePathsArray(['something'], '1')).toThrow();
         const paths = ["m/44'/242'/0'/6'","m/44'/242'/0'/6'"];
         expect(requestParser.parsePathsArray(paths, '1')).toEqual(paths);
     });
@@ -41,9 +41,9 @@ describe('RequestParser', () => {
         const requestParser = new RequestParser();
 
         expect(requestParser.parseLabel(undefined)).toBe(undefined);
-        expect( () => { requestParser.parseLabel(5); }).toThrow();
-        expect( requestParser.parseLabel('')).toBe(undefined);
-        expect( () => { requestParser.parseLabel({}); }).toThrow();
+        expect(() => requestParser.parseLabel(5)).toThrow();
+        expect(requestParser.parseLabel('')).toBe(undefined);
+        expect(() => requestParser.parseLabel({})).toThrow();
         const label = 'Ein Test';
         expect(requestParser.parseLabel(label)).toEqual(label);
     });
@@ -95,13 +95,13 @@ describe('RequestParser', () => {
     it('can parse indicesArrays', () => {
         const requestParser = new RequestParser();
 
-        expect( () => { requestParser.parseIndicesArray(undefined); }).toThrow();
-        expect( () => { requestParser.parseIndicesArray({x: 7}); }).toThrow();
-        expect( () => { requestParser.parseIndicesArray('ThisIsNotAnArray'); }).toThrow();
-        expect( () => { requestParser.parseIndicesArray(9); }).toThrow();
-        expect( () => { requestParser.parseIndicesArray([]); }).toThrow();
-        expect( () => { requestParser.parseIndicesArray([1,2,3,4,5]); }).toThrow();
-        expect( () => { requestParser.parseIndicesArray(["1","2","3"]); }).toThrow();
+        expect(() => requestParser.parseIndicesArray(undefined)).toThrow();
+        expect(() => requestParser.parseIndicesArray({x: 7})).toThrow();
+        expect(() => requestParser.parseIndicesArray('ThisIsNotAnArray')).toThrow();
+        expect(() => requestParser.parseIndicesArray(9)).toThrow();
+        expect(() => requestParser.parseIndicesArray([])).toThrow();
+        expect(() => requestParser.parseIndicesArray([1,2,3,4,5])).toThrow();
+        expect(() => requestParser.parseIndicesArray(["1","2","3"])).toThrow();
         const indicesArray = ["1'","2'","3'"];
         expect(requestParser.parseIndicesArray(indicesArray)).toEqual(indicesArray);
     });
@@ -109,9 +109,9 @@ describe('RequestParser', () => {
     it('can parse transactions', () => {
         const requestParser = new RequestParser();
 
-        expect( () => { requestParser.parseTransaction(undefined); }).toThrow();
-        expect( () => { requestParser.parseTransaction(5); }).toThrow();
-        expect( () => { requestParser.parseTransaction({}); }).toThrow();
+        expect(() => requestParser.parseTransaction(undefined)).toThrow();
+        expect(() => requestParser.parseTransaction(5)).toThrow();
+        expect(() => requestParser.parseTransaction({})).toThrow();
 
         const transaction = {
             data: new Uint8Array([84, 104, 97, 110, 107, 32, 121, 111, 117, 32, 102, 111, 114, 32, 115, 104, 111, 112, 112, 105, 110, 103, 32, 97, 116, 32, 115, 104, 111, 112, 46, 110, 105, 109, 105, 113, 46, 99, 111, 109, 32, 40, 72, 51, 88, 67, 48, 68, 41]),
@@ -138,33 +138,35 @@ describe('RequestParser', () => {
 
         const sender = transaction.sender;
         transaction.sender = transaction.recipient;
-        expect( () => { requestParser.parseTransaction(transaction); }).toThrow();
+        expect( () => requestParser.parseTransaction(transaction)).toThrow();
 
         transaction.sender = sender; // in case some tests need to be added
         // rest should be thrown (and tested) by core.
     });
 
-    it('can parse message', () => {
+    it('can parse messages', () => {
         const requestParser = new RequestParser();
 
-        expect( () => { requestParser.parseMessage(undefined); }).toThrow();
-        expect( () => { requestParser.parseMessage(5); }).toThrow();
-        expect( () => { requestParser.parseMessage({}); }).toThrow();
+        expect(() => requestParser.parseMessage(undefined)).toThrow();
+        expect(() => requestParser.parseMessage(5)).toThrow();
+        expect(() => requestParser.parseMessage({})).toThrow();
         expect(requestParser.parseMessage('123456')).toEqual(new Uint8Array([49, 50, 51, 52, 53, 54]));
         const message = new Uint8Array([238, 61, 13, 183, 158, 200, 247, 106, 130, 61, 9, 123, 134, 82, 60, 95, 16, 71, 39, 70]);
         expect(requestParser.parseMessage(message)).toEqual(message);
     });
 
-    it('can parse shopOrigin', () => {
+    it('can parse shopOrigins', () => {
         const requestParser = new RequestParser();
 
-        expect( () => { requestParser.parseShopOrigin(undefined); }).toThrow();
-        expect( () => { requestParser.parseShopOrigin(5); }).toThrow();
-        expect( () => { requestParser.parseShopOrigin({}); }).toThrow();
-        expect( () => { requestParser.parseShopOrigin('isThisAUrl?'); }).toThrow();
+        expect(() => requestParser.parseShopOrigin(undefined)).toThrow();
+        expect(() => requestParser.parseShopOrigin(5)).toThrow();
+        expect(() => requestParser.parseShopOrigin({})).toThrow();
+        expect(() => requestParser.parseShopOrigin('isThisAUrl?')).toThrow();
         let url = 'http://nimiq.com';
         expect(requestParser.parseShopOrigin(url)).toEqual('http://nimiq.com');
         url = 'http://nimiq.com/some/path/some/where/index.html?foo=bar';
         expect(requestParser.parseShopOrigin(url)).toEqual('http://nimiq.com');
     });
+
+    // no it('can parse addresses', ...) as it is already tested by core.
 });


### PR DESCRIPTION
Adds RequestParser from which ToplevelApi inherits. RequestParser provides parsing methods for the currently used properties of requests.
The Api classes of the specific requests now use those parse methods to parse the incoming request.

Also adds a test suit for the RequestParser.