### PR TITLE
Move parsed request types from client into Keyguard

### DIFF
--- a/client/types/KeyguardRequest.d.ts
+++ b/client/types/KeyguardRequest.d.ts
@@ -1,8 +1,4 @@
 declare namespace KeyguardRequest {
-    type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-
-    type Transform<T, K extends keyof T, E> = Omit<T, K> & E
-
     namespace Key {
         type Type = 0 | 1;
     }
@@ -18,8 +14,6 @@ declare namespace KeyguardRequest {
         legacyAccount: { label: string, address: Uint8Array };
     }
 
-    type KeyId2KeyInfo<T extends { keyId: string }> = Transform<T, 'keyId', { keyInfo: KeyInfoObject }>
-
     type BasicRequest = {
         appName: string
     }
@@ -28,8 +22,6 @@ declare namespace KeyguardRequest {
         keyId: string
         keyLabel?: string
     }
-
-    type ParsedSimpleRequest = KeyId2KeyInfo<SimpleRequest>
 
     type SimpleResult = {
         success: boolean
@@ -52,11 +44,6 @@ declare namespace KeyguardRequest {
         flags?: number
     }
 
-    type ConstructTransaction<T extends TransactionInfo> = Transform<T,
-        'sender' | 'senderType' | 'recipient' | 'recipientType' | 'value' | 'fee' |
-        'validityStartHeight' | 'data' | 'flags',
-        { transaction: Nimiq.ExtendedTransaction }>
-
     type SignTransactionRequestLayout = 'standard' | 'checkout' | 'cashlink'
 
     type SignTransactionRequest = SimpleRequest & TransactionInfo & {
@@ -69,9 +56,6 @@ declare namespace KeyguardRequest {
         recipientLabel?: string
     }
 
-    type ParsedSignTransactionRequest = ConstructTransaction<KeyId2KeyInfo<SignTransactionRequest>>
-        & { layout: SignTransactionRequestLayout }
-
     type SignTransactionResult = SignatureResult;
 
     type SignMessageRequest = SimpleRequest & {
@@ -80,8 +64,6 @@ declare namespace KeyguardRequest {
         signer: Uint8Array
         signerLabel?: string
     }
-
-    type ParsedSignMessageRequest = Transform<KeyId2KeyInfo<SignMessageRequest>, 'signer', { signer: Nimiq.Address }>
 
     type SignMessageResult = SignatureResult & {
         data: Uint8Array
@@ -112,8 +94,6 @@ declare namespace KeyguardRequest {
         baseKeyPath: string
         indicesToDerive: string[]
     }
-
-    type ParsedDeriveAddressRequest = KeyId2KeyInfo<DeriveAddressRequest>
 
     type DeriveAddressResult = {
         keyPath: string

--- a/src/request/change-passphrase/ChangePassphrase.js
+++ b/src/request/change-passphrase/ChangePassphrase.js
@@ -10,7 +10,7 @@ class ChangePassphrase {
      * If a complete page is missing it will be created.
      * However these pages wil be the default pages which usually don't match the applications requirements.
      * Refer to the corresponsing _build() to see the general Structure.
-     * @param {KeyguardRequest.ParsedSimpleRequest} request
+     * @param {ParsedSimpleRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/change-passphrase/ChangePassphraseApi.js
+++ b/src/request/change-passphrase/ChangePassphraseApi.js
@@ -27,7 +27,7 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
 
     /**
      * @param {KeyguardRequest.SimpleRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
+     * @returns {Promise<ParsedSimpleRequest>}
      */
     async parseRequest(request) {
         if (!request) {

--- a/src/request/derive-address/DeriveAddress.js
+++ b/src/request/derive-address/DeriveAddress.js
@@ -8,7 +8,7 @@
 
 class DeriveAddress {
     /**
-     * @param {KeyguardRequest.ParsedDeriveAddressRequest} request
+     * @param {ParsedDeriveAddressRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -24,7 +24,7 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
 
     /**
      * @param {KeyguardRequest.DeriveAddressRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedDeriveAddressRequest>}
+     * @returns {Promise<ParsedDeriveAddressRequest>}
      */
     async parseRequest(request) {
         if (!request) {

--- a/src/request/export/Export.js
+++ b/src/request/export/Export.js
@@ -7,7 +7,7 @@ class Export {
      * However these pages wil be the default pages which usually don't match the applications requirements.
      * Refer to the corresponsing _buildMoreExportOptions as well as
      * the Build functions of ExportWords and ExportFile to see the general Structure.
-     * @param {KeyguardRequest.ParsedSimpleRequest} request
+     * @param {ParsedSimpleRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -23,7 +23,7 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
 
     /**
      * @param {KeyguardRequest.SimpleRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
+     * @returns {Promise<ParsedSimpleRequest>}
      */
     async parseRequest(request) {
         if (!request) {

--- a/src/request/export/ExportFile.js
+++ b/src/request/export/ExportFile.js
@@ -11,7 +11,7 @@ class ExportFile extends Nimiq.Observable {
      * if a complete page is missing it will be created.
      * However these pages wil be the default pages which usually don't match the applications requirements.
      * Refer to the corresponsing _build(Privcy | RecoveryWords | ValidateWords) to see the general Structure.
-     * @param {KeyguardRequest.ParsedSimpleRequest} request
+     * @param {ParsedSimpleRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/export/ExportWords.js
+++ b/src/request/export/ExportWords.js
@@ -13,7 +13,7 @@ class ExportWords extends Nimiq.Observable {
      * if a complete page is missing it will be created.
      * However these pages wil be the default pages which usually don't match the applications requirements.
      * Refer to the corresponsing _build(Privcy | RecoveryWords | ValidateWords) to see the general Structure.
-     * @param {KeyguardRequest.ParsedSimpleRequest} request
+     * @param {ParsedSimpleRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/remove-key/RemoveKey.js
+++ b/src/request/remove-key/RemoveKey.js
@@ -12,7 +12,7 @@ class RemoveKey {
      * However these pages wil be the default pages which usually don't match the applications requirements.
      * Refer to the corresponsing _buildRemoveKey as well as
      * the Build functions of ExportWords and ExportFile to see the general Structure.
-     * @param {KeyguardRequest.ParsedSimpleRequest} request
+     * @param {ParsedSimpleRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -23,7 +23,7 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
 
     /**
      * @param {KeyguardRequest.SimpleRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSimpleRequest>}
+     * @returns {Promise<ParsedSimpleRequest>}
      */
     async parseRequest(request) {
         if (!request) {

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -10,7 +10,7 @@
 class SignMessage {
     /**
      * @param {HTMLDivElement} $page
-     * @param {KeyguardRequest.ParsedSignMessageRequest} request
+     * @param {ParsedSignMessageRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */
@@ -64,7 +64,7 @@ class SignMessage {
     }
 
     /**
-     * @param {KeyguardRequest.ParsedSignMessageRequest} request
+     * @param {ParsedSignMessageRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      * @param {string} [passphrase]

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -31,7 +31,7 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
 
     /**
      * @param {KeyguardRequest.SignMessageRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSignMessageRequest>}
+     * @returns {Promise<ParsedSignMessageRequest>}
      */
     async parseRequest(request) {
         if (!request) {

--- a/src/request/sign-transaction/BaseLayout.js
+++ b/src/request/sign-transaction/BaseLayout.js
@@ -8,7 +8,7 @@
 
 class BaseLayout {
     /**
-     * @param {KeyguardRequest.ParsedSignTransactionRequest} request
+     * @param {ParsedSignTransactionRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */
@@ -101,7 +101,7 @@ class BaseLayout {
     }
 
     /**
-     * @param {KeyguardRequest.ParsedSignTransactionRequest} request
+     * @param {ParsedSignTransactionRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      * @param {string} [passphrase]

--- a/src/request/sign-transaction/LayoutCheckout.js
+++ b/src/request/sign-transaction/LayoutCheckout.js
@@ -6,7 +6,7 @@
 class LayoutCheckout extends BaseLayout { // eslint-disable-line no-unused-vars
     /**
      * @param {?HTMLElement} $el
-     * @param {KeyguardRequest.ParsedSignTransactionRequest} request
+     * @param {ParsedSignTransactionRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/sign-transaction/LayoutStandard.js
+++ b/src/request/sign-transaction/LayoutStandard.js
@@ -4,7 +4,7 @@
 class LayoutStandard extends BaseLayout { // eslint-disable-line no-unused-vars
     /**
      * @param {?HTMLElement} $el
-     * @param {KeyguardRequest.ParsedSignTransactionRequest} request
+     * @param {ParsedSignTransactionRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -53,7 +53,7 @@ class SignTransactionApi extends TopLevelApi {
 
     /**
      * @param {KeyguardRequest.SignTransactionRequest} request
-     * @returns {Promise<KeyguardRequest.ParsedSignTransactionRequest>}
+     * @returns {Promise<ParsedSignTransactionRequest>}
      */
     async parseRequest(request) {
         if (!request) {

--- a/types/Keyguard.d.ts
+++ b/types/Keyguard.d.ts
@@ -43,3 +43,18 @@ type KeyRecord = {
     hasPin: boolean
     secret: Uint8Array
 }
+
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+type Transform<T, K extends keyof T, E> = Omit<T, K> & E
+type KeyId2KeyInfo<T extends { keyId: string }> = Transform<T, 'keyId', { keyInfo: KeyInfo }>
+type ConstructTransaction<T extends KeyguardRequest.TransactionInfo> = Transform<T,
+    'sender' | 'senderType' | 'recipient' | 'recipientType' | 'value' | 'fee' |
+    'validityStartHeight' | 'data' | 'flags',
+    { transaction: Nimiq.ExtendedTransaction }>
+
+type ParsedSimpleRequest = KeyId2KeyInfo<KeyguardRequest.SimpleRequest>
+type ParsedSignTransactionRequest = ConstructTransaction<KeyId2KeyInfo<KeyguardRequest.SignTransactionRequest>>
+    & { layout: KeyguardRequest.SignTransactionRequestLayout }
+type ParsedSignMessageRequest = Transform<KeyId2KeyInfo<KeyguardRequest.SignMessageRequest>,
+    'signer', { signer: Nimiq.Address }>
+type ParsedDeriveAddressRequest = KeyId2KeyInfo<KeyguardRequest.DeriveAddressRequest>


### PR DESCRIPTION
Parsing of requests happens in the Keyguard, not in the client. Thus it's only fitting to define and use the parsed types within the Keyguard, too.