### PR TITLE
Client RPC update

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nimiq/keyguard-next/client#readme",
   "dependencies": {
-    "@nimiq/rpc": "^0.1.0-beta.6"
+    "@nimiq/rpc": "^0.1.1"
   },
   "devDependencies": {
     "@nimiq/core-types": "^1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.1.6-beta.3",
+  "version": "0.1.6-beta.4",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.1.5",
+  "version": "0.1.6-beta.3",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nimiq/keyguard-next/client#readme",
   "dependencies": {
-    "@nimiq/rpc": "^0.1.0-beta.3"
+    "@nimiq/rpc": "^0.1.0-beta.6"
   },
   "devDependencies": {
     "@nimiq/core-types": "^1.0.0",

--- a/client/src/KeyguardClient.ts
+++ b/client/src/KeyguardClient.ts
@@ -19,6 +19,7 @@ export class KeyguardClient {
         endpoint = KeyguardClient.DEFAULT_ENDPOINT,
         defaultBehavior?: RequestBehavior,
         defaultIframeBehavior?: RequestBehavior,
+        preserveRequests?: boolean,
     ) {
         this._endpoint = endpoint;
         this._defaultBehavior = defaultBehavior || new RedirectRequestBehavior();
@@ -30,7 +31,7 @@ export class KeyguardClient {
             : RequestBehavior.getAllowedOrigin(this._endpoint);
 
         // Listen for response
-        this._redirectClient = new RedirectRpcClient('', allowedOrigin);
+        this._redirectClient = new RedirectRpcClient('', allowedOrigin, preserveRequests);
         this._redirectClient.onResponse('request', this._onResolve.bind(this), this._onReject.bind(this));
 
         this._observable = new Observable();

--- a/client/src/RequestBehavior.ts
+++ b/client/src/RequestBehavior.ts
@@ -49,10 +49,9 @@ export class RedirectRequestBehavior extends RequestBehavior {
 
     public async request(endpoint: string, command: KeyguardCommand, args: any[]): Promise<any> {
         const url = RedirectRequestBehavior.getRequestUrl(endpoint, command);
-        const origin = RequestBehavior.getAllowedOrigin(endpoint);
+        const allowedOrigin = RequestBehavior.getAllowedOrigin(endpoint);
 
-        const client = new RedirectRpcClient(url, origin);
-        await client.init();
+        const client = new RedirectRpcClient(url, allowedOrigin);
 
         const state = Object.assign({ __command: command }, this._localState);
         client.callAndSaveLocalState(this._returnUrl, state, 'request', ...args);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/core-types/-/core-types-1.0.0.tgz#a675cf2c151d9146e79934035e999bbd08a59d42"
   integrity sha512-OUDYAsEjuCmZewMZz8otPE6GMtvfxqbwtsa6oQ5okzRRQqNXkKTkR1/wM+DY1RcyiF141Fd9J7TnU4sJwzH94w==
 
-"@nimiq/rpc@^0.1.0-beta.3":
-  version "0.1.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.3.tgz#7af632bc76e6a2d8d045bb5e25ca948f657651ab"
-  integrity sha512-jcZy8EmYbbfViXJNXxX2BxZplJx1NXqNoOPZTWVBzg6QU9sN/y4iR6d+yDs6WEplMONh10VyDb2FVVTowYPKXA==
+"@nimiq/rpc@^0.1.0-beta.6":
+  version "0.1.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.0-beta.6.tgz#aeec8c55548fd2166a33f97b5838cb51a8caeb6d"
+  integrity sha512-69BCfjlaJEuY9AF9NKDjgUVrHs8gPEV4h9Tq7LkYLEPpvZVcOd1fmXeWSsvECqpjtGYtWGXcAjZ3QMQy9wy8lQ==
 
 "@types/estree@0.0.39":
   version "0.0.39"


### PR DESCRIPTION
Update RPC dependency to enable `preserveRequest` flag, don't check for incoming results when starting a request.