### PR TITLE
Fix legacy account migration under iOS

### DIFF
--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -20,7 +20,20 @@ class CookieJar { // eslint-disable-line no-unused-vars
             const match = document.cookie.match(new RegExp('accounts=([^;]+)'));
             if (match && match[1]) {
                 const decoded = decodeURIComponent(match[1]);
-                return JSON.parse(decoded);
+                const cookieAccounts = JSON.parse(decoded);
+
+                // Map from cookie format to AccountInfo format
+                return cookieAccounts.map(
+                    /**
+                     * @param {any} acc
+                     * @returns {AccountInfo}
+                     */
+                    acc => ({
+                        userFriendlyAddress: acc.address,
+                        type: acc.type,
+                        label: acc.label,
+                    }),
+                );
             }
             return [];
         }

--- a/tests/DummyData.spec.js
+++ b/tests/DummyData.spec.js
@@ -75,6 +75,14 @@ Dummy.deprecatedAccountInfos = [
     },
 ];
 
+Dummy.deprecatedAccountCookie = [
+    {
+        address: 'NQ71 CT4K 7R9R EHSB 7HY9 TSTP XNRQ L2RK 8U4U',
+        type: 'high',
+        label: 'Dummy account 1',
+    },
+];
+
 /** @type {AccountRecord[]} */
 Dummy.deprecatedAccountRecords = [
     Object.assign({}, Dummy.deprecatedAccountInfos[0], { encryptedKeyPair: Dummy.encryptedKeys[0] }),
@@ -95,7 +103,7 @@ Dummy.deprecatedAccount2KeyInfoObject = [{
 Dummy.keyInfoCookieEncoded = '0102ec615522906100ef553f34a779';
 
 /** @type {string} */
-Dummy.cookie = `k=${Dummy.keyInfoCookieEncoded};accounts=${JSON.stringify(Dummy.deprecatedAccountInfos)};some=thing;`;
+Dummy.cookie = `k=${Dummy.keyInfoCookieEncoded};accounts=${JSON.stringify(Dummy.deprecatedAccountCookie)};some=thing;`;
 
 Dummy.DUMMY_ACCOUNT_DATABASE_NAME = 'keyguard-dummy-account-database';
 Dummy.DUMMY_KEY_DATABASE_NAME = 'keyguard-dummy-key-database';


### PR DESCRIPTION
The account's address is actually stored under the `address` property in the legacy cookie, not under `userFriendlyAddress`.

In the legacy IndexedDB, it's still called `userFriendlyAddress` (that's why the usual migration code works with that property name), but the old Keyguard mapped it to `address` when exporting from the database, thus it was also stored as `address` in the cookie.