### PR TITLE
Enable reloading for self-rendering requests

### DIFF
--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -93,7 +93,7 @@ class TopLevelApi extends RequestParser { // eslint-disable-line no-unused-vars
                 return false;
             });
 
-            window.location.hash='loading';
+            window.location.hash = 'loading';
             this.onRequest(request).catch(reject);
         });
     }

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -93,6 +93,7 @@ class TopLevelApi extends RequestParser { // eslint-disable-line no-unused-vars
                 return false;
             });
 
+            window.location.hash='loading';
             this.onRequest(request).catch(reject);
         });
     }


### PR DESCRIPTION
set hash to loading before running request to trigger hash change on reload.

Solves #172 