### PR TITLE
Use ChromeHeadless stable again for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
   - client/node_modules
 
 addons:
-  chrome: beta
+  chrome: stable
   firefox: latest
 
 script:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,7 +60,7 @@ module.exports = function (/** @type {any} */ config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: process.env.TRAVIS ? ['FirefoxHeadless', 'ChromeHeadless'] : ['FirefoxHeadless', 'Chrome'],
+        browsers: ['FirefoxHeadless', 'ChromeHeadless'],
 
 
         // Continuous Integration mode


### PR DESCRIPTION
After one of the last Chrome updates, it's now possible again to use HeadlessChrome for tests.