### PR TITLE
Remove request API's onRequest

### DIFF
--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -129,6 +129,7 @@ class TopLevelApi extends RequestParser { // eslint-disable-line no-unused-vars
                 reject(new Errors.KeyguardError('Handler undefined'));
                 return;
             }
+
             try {
                 const handler = new this.Handler(parsedRequest, resolve, reject);
 
@@ -136,9 +137,9 @@ class TopLevelApi extends RequestParser { // eslint-disable-line no-unused-vars
 
                 this.setGlobalCloseButtonText(`${I18n.translatePhrase('back-to')} ${parsedRequest.appName}`);
 
-                TopLevelApi.setLoading(false);
-
                 handler.run();
+
+                TopLevelApi.setLoading(false);
             } catch (error) {
                 reject(error);
             }
@@ -148,7 +149,7 @@ class TopLevelApi extends RequestParser { // eslint-disable-line no-unused-vars
     /**
      * Overwritten by each request's API class
      *
-     * @param {KeyguardRequest.KeyguardRequest} request
+     * @param {KeyguardRequest.Request} request
      * @returns {Promise<ParsedRequest>}
      * @abstract
      */

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -125,31 +125,49 @@ class TopLevelApi extends RequestParser { // eslint-disable-line no-unused-vars
                 return false;
             });
 
-            this.onRequest(parsedRequest).catch(reject);
-            this.setGlobalCloseButtonText(`${I18n.translatePhrase('back-to')} ${parsedRequest.appName}`);
-            TopLevelApi.setLoading(false);
+            if (!this.Handler) {
+                reject(new Errors.KeyguardError('Handler undefined'));
+                return;
+            }
+            try {
+                const handler = new this.Handler(parsedRequest, resolve, reject);
+
+                this.onBeforeRun(parsedRequest);
+
+                this.setGlobalCloseButtonText(`${I18n.translatePhrase('back-to')} ${parsedRequest.appName}`);
+
+                TopLevelApi.setLoading(false);
+
+                handler.run();
+            } catch (error) {
+                reject(error);
+            }
         });
     }
 
     /**
      * Overwritten by each request's API class
      *
-     * @param {ParsedRequest} request
-     * @abstract
-     */
-    async onRequest(request) { // eslint-disable-line no-unused-vars
-        throw new Error('onRequest not implemented');
-    }
-
-    /**
-     * Overwritten by each request's API class
-     *
-     * @param {KeyguardRequest.Request} request
+     * @param {KeyguardRequest.KeyguardRequest} request
      * @returns {Promise<ParsedRequest>}
      * @abstract
      */
     async parseRequest(request) { // eslint-disable-line no-unused-vars
         throw new Error('parseRequest not implemented');
+    }
+
+    /** @type {Newable?} */
+    get Handler() {
+        return null;
+    }
+
+    /**
+     * Can be overwritten by a request's API class to excute code before the handler's run() is called
+     *
+     * @param {ParsedRequest} parsedRequest
+     */
+    async onBeforeRun(parsedRequest) { // eslint-disable-line no-unused-vars
+        // noop
     }
 
     /**

--- a/src/request/change-passphrase/ChangePassphraseApi.js
+++ b/src/request/change-passphrase/ChangePassphraseApi.js
@@ -4,14 +4,6 @@
 
 class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
-     * @param {ParsedSimpleRequest} request
-     */
-    async onRequest(request) {
-        const handler = new ChangePassphrase(request, this.resolve.bind(this), this.reject.bind(this));
-        handler.run();
-    }
-
-    /**
      * @param {KeyguardRequest.SimpleRequest} request
      * @returns {Promise<ParsedSimpleRequest>}
      */
@@ -26,5 +18,9 @@ class ChangePassphraseApi extends TopLevelApi { // eslint-disable-line no-unused
         parsedRequest.keyLabel = this.parseLabel(request.keyLabel);
 
         return parsedRequest;
+    }
+
+    get Handler() {
+        return ChangePassphrase;
     }
 }

--- a/src/request/create/CreateApi.js
+++ b/src/request/create/CreateApi.js
@@ -5,14 +5,6 @@
 class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.CreateRequest} request
-     */
-    async onRequest(request) {
-        const handler = new Create(request, this.resolve.bind(this), this.reject.bind(this));
-        handler.run();
-    }
-
-    /**
-     * @param {KeyguardRequest.CreateRequest} request
      * @returns {Promise<KeyguardRequest.CreateRequest>}
      */
     async parseRequest(request) {
@@ -25,5 +17,9 @@ class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         parsedRequest.defaultKeyPath = this.parsePath(request.defaultKeyPath, 'defaultKeyPath');
 
         return parsedRequest;
+    }
+
+    get Handler() {
+        return Create;
     }
 }

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -5,14 +5,6 @@
 
 class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
-     * @param {ParsedDeriveAddressRequest} request
-     */
-    async onRequest(request) {
-        const handler = new DeriveAddress(request, this.resolve.bind(this), this.reject.bind(this));
-        handler.run();
-    }
-
-    /**
      * @param {KeyguardRequest.DeriveAddressRequest} request
      * @returns {Promise<ParsedDeriveAddressRequest>}
      */
@@ -32,5 +24,9 @@ class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-va
         parsedRequest.indicesToDerive = this.parseIndicesArray(request.indicesToDerive);
 
         return parsedRequest;
+    }
+
+    get Handler() {
+        return DeriveAddress;
     }
 }

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -4,14 +4,6 @@
 
 class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
-     * @param {ParsedSimpleRequest} request
-     */
-    async onRequest(request) {
-        const exportHandler = new Export(request, this.resolve.bind(this), this.reject.bind(this));
-        exportHandler.run();
-    }
-
-    /**
      * @param {KeyguardRequest.SimpleRequest} request
      * @returns {Promise<ParsedSimpleRequest>}
      */
@@ -27,5 +19,9 @@ class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         // parsedRequest.usedKeyPaths = this.parsePathsArray(request.usedKeyPaths, 'usedKeyPaths');
 
         return parsedRequest;
+    }
+
+    get Handler() {
+        return Export;
     }
 }

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -5,14 +5,6 @@
 class ImportApi extends TopLevelApi {
     /**
      * @param {KeyguardRequest.ImportRequest} request
-     */
-    async onRequest(request) {
-        const importFileHandler = new ImportFile(request, this.resolve.bind(this), this.reject.bind(this));
-        importFileHandler.run();
-    }
-
-    /**
-     * @param {KeyguardRequest.ImportRequest} request
      * @returns {Promise<KeyguardRequest.ImportRequest>}
      */
     async parseRequest(request) {
@@ -26,6 +18,10 @@ class ImportApi extends TopLevelApi {
         parsedRequest.requestedKeyPaths = this.parsePathsArray(request.requestedKeyPaths, ' requestKeyPaths');
 
         return parsedRequest;
+    }
+
+    get Handler() {
+        return ImportFile;
     }
 }
 

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -4,14 +4,6 @@
 
 class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
-     * @param {ParsedRemoveKeyRequest} request
-     */
-    async onRequest(request) {
-        const removeKeyHandler = new RemoveKey(request, this.resolve.bind(this), this.reject.bind(this));
-        removeKeyHandler.run();
-    }
-
-    /**
      * @param {KeyguardRequest.RemoveKeyRequest} request
      * @returns {Promise<ParsedRemoveKeyRequest>}
      */
@@ -32,5 +24,9 @@ class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         parsedRequest.keyLabel = parsedLabel;
 
         return parsedRequest;
+    }
+
+    get Handler() {
+        return RemoveKey;
     }
 }

--- a/src/request/sign-message/SignMessage.js
+++ b/src/request/sign-message/SignMessage.js
@@ -10,12 +10,14 @@
 
 class SignMessage {
     /**
-     * @param {HTMLDivElement} $page
      * @param {ParsedSignMessageRequest} request
      * @param {Function} resolve
      * @param {Function} reject
      */
-    constructor($page, request, resolve, reject) {
+    constructor(request, resolve, reject) {
+        /** @type {HTMLDivElement} */
+        const $page = (document.getElementById(SignMessage.Pages.AUTHORIZE));
+
         /** @type {HTMLDivElement} */
         const $signerIdenticon = ($page.querySelector('#signer-identicon'));
 

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -4,22 +4,6 @@
 
 class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
-     * @param {ParsedSignMessageRequest} request
-     */
-    async onRequest(request) {
-        /** @type {HTMLDivElement} */
-        const $page = (document.getElementById(SignMessage.Pages.AUTHORIZE));
-
-        const handler = new SignMessage(
-            $page,
-            request,
-            this.resolve.bind(this),
-            this.reject.bind(this),
-        );
-        handler.run();
-    }
-
-    /**
      * @param {KeyguardRequest.SignMessageRequest} request
      * @returns {Promise<ParsedSignMessageRequest>}
      */
@@ -38,5 +22,9 @@ class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
         parsedRequest.signer = this.parseAddress(request.signer, 'signer');
 
         return parsedRequest;
+    }
+
+    get Handler() {
+        return SignMessage;
     }
 }

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -5,19 +5,6 @@
 
 class SignTransactionApi extends TopLevelApi {
     /**
-     * @param {ParsedSignTransactionRequest} request
-     */
-    async onRequest(request) {
-        const handler = new SignTransaction(request, this.resolve.bind(this), this.reject.bind(this));
-
-        if (request.layout === SignTransactionApi.Layouts.CHECKOUT) {
-            this.setGlobalCloseButtonText(I18n.translatePhrase('sign-tx-cancel-payment'));
-        }
-
-        handler.run();
-    }
-
-    /**
      * Checks that the given layout is valid
      * @param {any} layout
      * @returns {any}
@@ -62,6 +49,19 @@ class SignTransactionApi extends TopLevelApi {
         }
 
         return parsedRequest;
+    }
+
+    /**
+     * @param {ParsedSignTransactionRequest} parsedRequest
+     */
+    async onBeforeRun(parsedRequest) {
+        if (parsedRequest.layout === SignTransactionApi.Layouts.CHECKOUT) {
+            this.setGlobalCloseButtonText(I18n.translatePhrase('sign-tx-cancel-payment'));
+        }
+    }
+
+    get Handler() {
+        return SignTransaction;
     }
 }
 


### PR DESCRIPTION
This PR removes the `onRequest()` method from the API classes of each requests.

Instead a getter on the Handler class is used to enable the TopLevelApi to execute all code necessary. 

A `onBeforeRun(parsedRequest)` hook is created to allow API classes to execute code before the handler's `run()` is called.