### PR TITLE
Import words result fix

### DIFF
--- a/src/components/FlippableHandler.css
+++ b/src/components/FlippableHandler.css
@@ -39,3 +39,8 @@
 #rotation-container > .page:target {
     z-index: 3;
 }
+
+.nq-card.nq-blue-bg {
+    background-image: var(--nimiq-blue-bg);
+    color: white;
+}

--- a/src/lib/Constants.js
+++ b/src/lib/Constants.js
@@ -16,4 +16,5 @@ const Constants = { // eslint-disable-line no-unused-vars
         MAIN: 'main',
     },
     LEGACY_DERIVATION_PATH: 'm/0\'',
+    DEFAULT_DERIVATION_PATH: 'm/44\'/242\'/0\'/0\'',
 };

--- a/src/request/import/ImportWords.js
+++ b/src/request/import/ImportWords.js
@@ -185,14 +185,16 @@ class ImportWords {
                     keyPath,
                     address: key.deriveAddress(keyPath).serialize(),
                 }));
-                this._keyResults.push({
+
+                /** @type {KeyguardRequest.SingleKeyResult?} */
+                const result = {
                     keyId: await KeyStore.instance.put(key, encryptionKey || undefined),
                     keyType: Nimiq.Secret.Type.ENTROPY,
                     addresses,
-                });
-                // this._keyResults.entropy.keyId = await KeyStore.instance.put(key, encryptionKey || undefined);
+                };
+                this._keyResults.push(result);
                 const secretString = Nimiq.BufferUtils.toBase64(key.secret.serialize());
-                sessionStorage.setItem(ImportApi.SESSION_STORAGE_KEY_PREFIX + key.id, secretString);
+                sessionStorage.setItem(ImportApi.SESSION_STORAGE_KEY_PREFIX + result.keyId, secretString);
 
                 if (encryptionKey) {
                     // Make the encrypted secret available for the Login File
@@ -206,14 +208,17 @@ class ImportWords {
             }
             if (this._secrets.privateKey) {
                 const key = new Key(this._secrets.privateKey, false);
-                this._keyResults.push({
+                const result = {
                     keyId: await KeyStore.instance.put(key, encryptionKey || undefined),
                     keyType: Nimiq.Secret.Type.PRIVATE_KEY,
                     addresses: [{
                         keyPath: Constants.LEGACY_DERIVATION_PATH,
                         address: key.deriveAddress('').serialize(),
                     }],
-                });
+                };
+                this._keyResults.push(result);
+                const secretString = Nimiq.BufferUtils.toBase64(key.secret.serialize());
+                sessionStorage.setItem(ImportApi.SESSION_STORAGE_KEY_PREFIX + result.keyId, secretString);
             } else {
                 TopLevelApi.setLoading(false);
             }

--- a/src/request/import/ImportWords.js
+++ b/src/request/import/ImportWords.js
@@ -212,7 +212,7 @@ class ImportWords {
                     keyType: Nimiq.Secret.Type.PRIVATE_KEY,
                     addresses: [{
                         keyPath: Constants.LEGACY_DERIVATION_PATH,
-                        address: key.deriveAddress('').serialize(),
+                        address: key.deriveAddress(Constants.LEGACY_DERIVATION_PATH).serialize(),
                     }],
                 };
                 this._keyResults.push(result);

--- a/src/request/import/ImportWords.js
+++ b/src/request/import/ImportWords.js
@@ -88,7 +88,7 @@ class ImportWords {
                 const color = Iqons.getBackgroundColorIndex(
                     new Nimiq.Address(
                         // use color of first address as loginFile color
-                        key.deriveAddress('m/44\'/242\'/0\'/0\'').serialize(),
+                        key.deriveAddress(Constants.DEFAULT_DERIVATION_PATH).serialize(),
                     ).toUserFriendlyAddress(),
                 );
                 const colorString = LoginFile.CONFIG[color].name;
@@ -108,7 +108,7 @@ class ImportWords {
 
             const key = new Key(/** @type {Nimiq.Entropy} */(this._secrets.entropy), false);
             const firstAddress = new Nimiq.Address(
-                key.deriveAddress('m/44\'/242\'/0\'/0\'').serialize(),
+                key.deriveAddress(Constants.DEFAULT_DERIVATION_PATH).serialize(),
             );
             downloadLoginFile.setEncryptedEntropy(
                 /** @type {Nimiq.SerialBuffer} */ (this._encryptedSecret),
@@ -186,7 +186,6 @@ class ImportWords {
                     address: key.deriveAddress(keyPath).serialize(),
                 }));
 
-                /** @type {KeyguardRequest.SingleKeyResult?} */
                 const result = {
                     keyId: await KeyStore.instance.put(key, encryptionKey || undefined),
                     keyType: Nimiq.Secret.Type.ENTROPY,
@@ -217,8 +216,6 @@ class ImportWords {
                     }],
                 };
                 this._keyResults.push(result);
-                const secretString = Nimiq.BufferUtils.toBase64(key.secret.serialize());
-                sessionStorage.setItem(ImportApi.SESSION_STORAGE_KEY_PREFIX + result.keyId, secretString);
             } else {
                 TopLevelApi.setLoading(false);
             }


### PR DESCRIPTION
This PR changes Import Words to return an array of SingleKeyResults instead of an Object. 
The counter Part in Accounts that can deal with this array is still pending and only the first returned array element will get checked.