### PR TITLE
Expose KeyguardClient returnUrl

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.2.5-beta.2",
+  "version": "0.2.5-beta.3",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",

--- a/client/src/KeyguardClient.ts
+++ b/client/src/KeyguardClient.ts
@@ -83,11 +83,12 @@ export class KeyguardClient {
 
     constructor(
         endpoint = KeyguardClient.DEFAULT_ENDPOINT,
+        returnURL?: string,
         localState?: any,
         preserveRequests?: boolean,
     ) {
         this._endpoint = endpoint;
-        this._redirectBehavior = new RedirectRequestBehavior(undefined, localState);
+        this._redirectBehavior = new RedirectRequestBehavior(returnURL, localState);
         this._iframeBehavior = new IFrameRequestBehavior();
 
         // If this is a page-reload, allow location.origin as RPC origin


### PR DESCRIPTION
To enable the accountsmanager to tell the KeyguardClient a custom return URL (instead of the RPC's default), we need to expose the setting.

Coordinated Accounts Manager PR: https://github.com/nimiq/accounts/pull/152