### PR TITLE
Add core-web dependency in client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.2.3",
+  "version": "0.2.5-beta.2",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/nimiq/keyguard-next/client#readme",
   "dependencies": {
-    "@nimiq/rpc": "^0.1.1"
+    "@nimiq/rpc": "^0.1.1",
+    "@nimiq/core-web": "1.4.3"
   },
   "devDependencies": {
     "rollup": "^0.64.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@nimiq/core-web@1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.4.3.tgz#190d7390324623672fafbbc93841bcf215d2af01"
+  integrity sha512-47JMAx8bFcr2uev+QgX4saBUvRQo/8akQdpvf0z1F5N3I8FPyIfEWRjPW2Xu28C+MOdIZ/VkHL/YmMiGBBtEMA==
+
 "@nimiq/rpc@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.1.tgz#7f9b10faab6cc589691db562047d136f0513bf98"


### PR DESCRIPTION
We need to add @nimiq/core-web as dependency (for typing only). I noticed this when I tried to replace network-client by nano-api in accounts, which removed the former present @nimiq/core-web dependency there.