### PR TITLE
add TemplateTags and tag many uses of template strings with number of…

### DIFF
--- a/src/components/AddressInfo.js
+++ b/src/components/AddressInfo.js
@@ -71,7 +71,7 @@ class AddressInfo {
 }
 
 /* eslint-disable max-len */
-AddressInfo.HEXAGON_CLIP_PATH = TemplateTags.noVariables`
+AddressInfo.HEXAGON_CLIP_PATH = TemplateTags.noVars`
     <svg width="0" height="0" viewBox="0 0 146 146">
         <defs>
             <clipPath id="nimiq-rounded-hexagon" clipPathUnits="objectBoundingBox">

--- a/src/components/AddressInfo.js
+++ b/src/components/AddressInfo.js
@@ -1,4 +1,5 @@
 /* global Identicon */
+/* global TemplateTags */
 
 class AddressInfo {
     /**
@@ -70,7 +71,7 @@ class AddressInfo {
 }
 
 /* eslint-disable max-len */
-AddressInfo.HEXAGON_CLIP_PATH = `
+AddressInfo.HEXAGON_CLIP_PATH = TemplateTags.noVariables`
     <svg width="0" height="0" viewBox="0 0 146 146">
         <defs>
             <clipPath id="nimiq-rounded-hexagon" clipPathUnits="objectBoundingBox">

--- a/src/components/DownloadLoginFile.js
+++ b/src/components/DownloadLoginFile.js
@@ -48,7 +48,7 @@ class DownloadLoginFile extends Nimiq.Observable {
         $el.classList.add('download-loginfile');
 
         /* eslint-disable max-len */
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <img class="loginfile" src=""></img>
 
             <svg class="long-touch-indicator" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">

--- a/src/components/DownloadLoginFile.js
+++ b/src/components/DownloadLoginFile.js
@@ -4,6 +4,7 @@
 /* global KeyStore */
 /* global Errors */
 /* global IqonHash */
+/* global TemplateTags */
 
 class DownloadLoginFile extends Nimiq.Observable {
     /**
@@ -47,7 +48,7 @@ class DownloadLoginFile extends Nimiq.Observable {
         $el.classList.add('download-loginfile');
 
         /* eslint-disable max-len */
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <img class="loginfile" src=""></img>
 
             <svg class="long-touch-indicator" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">

--- a/src/components/FileImporter.js
+++ b/src/components/FileImporter.js
@@ -3,6 +3,7 @@
 /* global QrScanner */
 /* global I18n */
 /* global LoginFile */
+/* global TemplateTags */
 
 class FileImporter extends Nimiq.Observable {
     /**
@@ -40,7 +41,7 @@ class FileImporter extends Nimiq.Observable {
         $el = $el || document.createElement('label');
         $el.classList.add('file-import');
 
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <h3 class="nq-h3 nq-light-blue" data-i18n="file-import-prompt">Drag here or click to upload</h3>
             <span class="error-message"></span>
             <div class="qr-code"></div>

--- a/src/components/FileImporter.js
+++ b/src/components/FileImporter.js
@@ -41,7 +41,7 @@ class FileImporter extends Nimiq.Observable {
         $el = $el || document.createElement('label');
         $el.classList.add('file-import');
 
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <h3 class="nq-h3 nq-light-blue" data-i18n="file-import-prompt">Drag here or click to upload</h3>
             <span class="error-message"></span>
             <div class="qr-code"></div>

--- a/src/components/LoginFileIcon.js
+++ b/src/components/LoginFileIcon.js
@@ -13,7 +13,7 @@ class LoginFileIcon { // eslint-disable-line no-unused-vars
         $el.classList.add('nq-icon', 'login-file-icon');
 
         /* eslint-disable max-len */
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <svg class="nq-icon lock">
                 <use class="lock-unlocked" xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-lock-unlocked"/>
                 <use class="lock-locked" xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-lock-locked"/>

--- a/src/components/LoginFileIcon.js
+++ b/src/components/LoginFileIcon.js
@@ -1,3 +1,5 @@
+/* global TemplateTags */
+
 class LoginFileIcon { // eslint-disable-line no-unused-vars
     /**
      *
@@ -11,7 +13,7 @@ class LoginFileIcon { // eslint-disable-line no-unused-vars
         $el.classList.add('nq-icon', 'login-file-icon');
 
         /* eslint-disable max-len */
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <svg class="nq-icon lock">
                 <use class="lock-unlocked" xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-lock-unlocked"/>
                 <use class="lock-locked" xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-lock-locked"/>

--- a/src/components/NoReferrerErrorPage.js
+++ b/src/components/NoReferrerErrorPage.js
@@ -1,4 +1,5 @@
 /* global I18n */
+/* global TemplateTags */
 
 class NoReferrerErrorPage { // eslint-disable-line no-unused-vars
     constructor() {
@@ -21,7 +22,7 @@ class NoReferrerErrorPage { // eslint-disable-line no-unused-vars
         $element.classList.add('page');
         $element.id = 'error';
 
-        $element.innerHTML = `
+        $element.innerHTML = TemplateTags.noVariables`
             <h1 class="nq-h1" data-i18n="error-no-referrer-heading">That went wrong :(</h1>
             <div data-i18n="error-no-referrer-message">
                 We could not verify the origin of your request. Please go back and try again.

--- a/src/components/NoReferrerErrorPage.js
+++ b/src/components/NoReferrerErrorPage.js
@@ -22,7 +22,7 @@ class NoReferrerErrorPage { // eslint-disable-line no-unused-vars
         $element.classList.add('page');
         $element.id = 'error';
 
-        $element.innerHTML = TemplateTags.noVariables`
+        $element.innerHTML = TemplateTags.noVars`
             <h1 class="nq-h1" data-i18n="error-no-referrer-heading">That went wrong :(</h1>
             <div data-i18n="error-no-referrer-message">
                 We could not verify the origin of your request. Please go back and try again.

--- a/src/components/PasswordBox.js
+++ b/src/components/PasswordBox.js
@@ -69,7 +69,7 @@ class PasswordBox extends Nimiq.Observable {
 
         if (!buttonVersions[options.buttonI18nTag]) throw new Error('PasswordBox button i18n tag not defined');
 
-        $el.innerHTML = TemplateTags.hasVariables(1)`
+        $el.innerHTML = TemplateTags.hasVars(1)`
             <a class="cancel">
                 <svg class="nq-icon">
                     <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-close"/>

--- a/src/components/PasswordBox.js
+++ b/src/components/PasswordBox.js
@@ -1,6 +1,7 @@
 /* global Nimiq */
 /* global I18n */
 /* global PasswordInput */
+/* global TemplateTags */
 
 class PasswordBox extends Nimiq.Observable {
     // eslint-disable-next-line valid-jsdoc, max-len
@@ -68,7 +69,7 @@ class PasswordBox extends Nimiq.Observable {
 
         if (!buttonVersions[options.buttonI18nTag]) throw new Error('PasswordBox button i18n tag not defined');
 
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.hasVariables(1)`
             <a class="cancel">
                 <svg class="nq-icon">
                     <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-close"/>

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -1,6 +1,7 @@
 /* global Nimiq */
 /* global AnimationUtils */
 /* global I18n */
+/* global TemplateTags */
 
 class PasswordInput extends Nimiq.Observable {
     /**
@@ -35,7 +36,7 @@ class PasswordInput extends Nimiq.Observable {
         $el.classList.add('password-input');
 
         /* eslint-disable max-len */
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <div class="input-container">
                 <div class="input-wrapper">
                     <input class="password" type="password" placeholder="Enter password">

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -36,7 +36,7 @@ class PasswordInput extends Nimiq.Observable {
         $el.classList.add('password-input');
 
         /* eslint-disable max-len */
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <div class="input-container">
                 <div class="input-wrapper">
                     <input class="password" type="password" placeholder="Enter password">

--- a/src/components/PasswordSetterBox.js
+++ b/src/components/PasswordSetterBox.js
@@ -48,7 +48,7 @@ class PasswordSetterBox extends Nimiq.Observable {
         $el.classList.add('password-box', 'actionbox', 'setter', `nq-${options.bgColor}-bg`);
 
         /* eslint-disable max-len */
-        $el.innerHTML = TemplateTags.hasVariables(1)`
+        $el.innerHTML = TemplateTags.hasVars(1)`
             <div class="password-strength strength-short  nq-text-s" data-i18n="passwordbox-password-strength-short" >Enter at least 8 characters</div>
             <div class="password-strength strength-weak   nq-text-s" data-i18n="passwordbox-password-strength-weak"  >That password is too weak</div>
             <div class="password-strength strength-good   nq-text-s" data-i18n="passwordbox-password-strength-good"  >Ok, that is an average password</div>
@@ -60,7 +60,7 @@ class PasswordSetterBox extends Nimiq.Observable {
 
             <button class="submit" data-i18n="passwordbox-continue">Continue</button>
 
-            ${options.hideSkip ? '' : TemplateTags.noVariables`
+            ${options.hideSkip ? '' : TemplateTags.noVars`
                 <a tabindex="0" class="password-skip nq-text-s">
                     <span data-i18n="passwordbox-password-skip">Skip for now</span>
                     <svg class="nq-icon">

--- a/src/components/PasswordSetterBox.js
+++ b/src/components/PasswordSetterBox.js
@@ -3,6 +3,7 @@
 /* global PasswordInput */
 /* global AnimationUtils */
 /* global PasswordStrength */
+/* global TemplateTags */
 
 class PasswordSetterBox extends Nimiq.Observable {
     /**
@@ -47,7 +48,7 @@ class PasswordSetterBox extends Nimiq.Observable {
         $el.classList.add('password-box', 'actionbox', 'setter', `nq-${options.bgColor}-bg`);
 
         /* eslint-disable max-len */
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.hasVariables(1)`
             <div class="password-strength strength-short  nq-text-s" data-i18n="passwordbox-password-strength-short" >Enter at least 8 characters</div>
             <div class="password-strength strength-weak   nq-text-s" data-i18n="passwordbox-password-strength-weak"  >That password is too weak</div>
             <div class="password-strength strength-good   nq-text-s" data-i18n="passwordbox-password-strength-good"  >Ok, that is an average password</div>
@@ -59,7 +60,7 @@ class PasswordSetterBox extends Nimiq.Observable {
 
             <button class="submit" data-i18n="passwordbox-continue">Continue</button>
 
-            ${options.hideSkip ? '' : `
+            ${options.hideSkip ? '' : TemplateTags.noVariables`
                 <a tabindex="0" class="password-skip nq-text-s">
                     <span data-i18n="passwordbox-password-skip">Skip for now</span>
                     <svg class="nq-icon">

--- a/src/components/PaymentInfoLine.js
+++ b/src/components/PaymentInfoLine.js
@@ -23,7 +23,7 @@ class PaymentInfoLine extends Nimiq.Observable { // eslint-disable-line no-unuse
         $el = $el || document.createElement('div');
         $el.classList.add('payment-info-line', 'nq-label');
 
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <div class="description">
                 Payment to
                 <span domain></span>

--- a/src/components/PaymentInfoLine.js
+++ b/src/components/PaymentInfoLine.js
@@ -1,4 +1,5 @@
 /* global Nimiq */
+/* global TemplateTags */
 
 class PaymentInfoLine extends Nimiq.Observable { // eslint-disable-line no-unused-vars
     /**
@@ -22,7 +23,7 @@ class PaymentInfoLine extends Nimiq.Observable { // eslint-disable-line no-unuse
         $el = $el || document.createElement('div');
         $el.classList.add('payment-info-line', 'nq-label');
 
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <div class="description">
                 Payment to
                 <span domain></span>

--- a/src/components/ProgressIndicator.js
+++ b/src/components/ProgressIndicator.js
@@ -25,7 +25,7 @@ class ProgressIndicator extends Nimiq.Observable { // eslint-disable-line no-unu
         let html = '';
 
         for (let i = 0; i < numberOfSteps; i++) {
-            html += TemplateTags.hasVariables(1)`<div class="indicator step-${i + 1}"></div>`;
+            html += TemplateTags.hasVars(1)`<div class="indicator step-${i + 1}"></div>`;
         }
 
         $el.innerHTML = html;

--- a/src/components/ProgressIndicator.js
+++ b/src/components/ProgressIndicator.js
@@ -1,4 +1,5 @@
 /* global Nimiq */
+/* global TemplateTags */
 
 class ProgressIndicator extends Nimiq.Observable { // eslint-disable-line no-unused-vars
     /**
@@ -24,7 +25,7 @@ class ProgressIndicator extends Nimiq.Observable { // eslint-disable-line no-unu
         let html = '';
 
         for (let i = 0; i < numberOfSteps; i++) {
-            html += `<div class="indicator step-${i + 1}"></div>`;
+            html += TemplateTags.hasVariables(1)`<div class="indicator step-${i + 1}"></div>`;
         }
 
         $el.innerHTML = html;

--- a/src/components/RecoveryWords.js
+++ b/src/components/RecoveryWords.js
@@ -44,7 +44,7 @@ class RecoveryWords extends Nimiq.Observable {
         $el = $el || document.createElement('div');
         $el.classList.add('recovery-words');
 
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <div class="words-container">
                 <div class="word-section"></div>
             </div>

--- a/src/components/RecoveryWords.js
+++ b/src/components/RecoveryWords.js
@@ -2,6 +2,7 @@
 /* global I18n */
 /* global RecoveryWordsInputField */
 /* global AnimationUtils */
+/* global TemplateTags */
 
 class RecoveryWords extends Nimiq.Observable {
     /**
@@ -43,7 +44,7 @@ class RecoveryWords extends Nimiq.Observable {
         $el = $el || document.createElement('div');
         $el.classList.add('recovery-words');
 
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <div class="words-container">
                 <div class="word-section"></div>
             </div>
@@ -70,7 +71,7 @@ class RecoveryWords extends Nimiq.Observable {
 
                 const $wordNumber = document.createElement('span');
                 $wordNumber.classList.add('word-number');
-                $wordNumber.textContent = `${i <= 8 ? '0' : ''}${i + 1}`;
+                $wordNumber.textContent = `${i < 9 ? '0' : ''}${i + 1}`;
 
                 const word = document.createElement('div');
                 word.classList.add('word', 'complete');

--- a/src/lib/IqonHash.js
+++ b/src/lib/IqonHash.js
@@ -13,10 +13,11 @@ class IqonHash { /* eslint-disable-line no-unused-vars */
      * @returns {string}
      */
     static hash(text) {
-        const fullHash = (`${text
+        const fullHash = text
             .split('')
             .map(c => Number(c.charCodeAt(0)) + 3)
-            .reduce((a, e) => a * (1 - a) * this._chaosHash(e), 0.5)}`)
+            .reduce((a, e) => a * (1 - a) * this._chaosHash(e), 0.5)
+            .toString()
             .split('')
             .reduce((a, e) => e + a, '');
 

--- a/src/lib/Iqons.js
+++ b/src/lib/Iqons.js
@@ -27,7 +27,7 @@ class Iqons {
      */
     static async toDataUrl(text) {
         const base64string = btoa(await this.svg(text));
-        return TemplateTags.hasVariables(1)`data:image/svg+xml;base64,${base64string.replace(/#/g, '%23')}`;
+        return TemplateTags.hasVars(1)`data:image/svg+xml;base64,${base64string.replace(/#/g, '%23')}`;
     }
 
     /**
@@ -39,7 +39,7 @@ class Iqons {
         color = color || '#bbb';
         strokeWidth = strokeWidth || 1;
         /* eslint-disable max-len */
-        return TemplateTags.hasVariables(4)`<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
+        return TemplateTags.hasVars(4)`<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
             <path fill="none" stroke="${color}" stroke-width="${2 * strokeWidth}" transform="translate(0, 8) scale(0.5)" d="M251.6 17.34l63.53 110.03c5.72 9.9 5.72 22.1 0 32L251.6 269.4c-5.7 9.9-16.27 16-27.7 16H96.83c-11.43 0-22-6.1-27.7-16L5.6 159.37c-5.7-9.9-5.7-22.1 0-32L69.14 17.34c5.72-9.9 16.28-16 27.7-16H223.9c11.43 0 22 6.1 27.7 16z"/>
             <g transform="scale(0.9) translate(9, 8)">
                 <circle cx="80" cy="80" r="40" fill="none" stroke="${color}" stroke-width="${strokeWidth}" opacity=".9"></circle>
@@ -55,7 +55,7 @@ class Iqons {
      * @returns {string}
      */
     static placeholderToDataUrl(color, strokeWidth) {
-        return TemplateTags.hasVariables(1)`data:image/svg+xml;base64,${btoa(this.placeholder(color, strokeWidth))}`;
+        return TemplateTags.hasVars(1)`data:image/svg+xml;base64,${btoa(this.placeholder(color, strokeWidth))}`;
     }
 
     /* Private API */
@@ -100,7 +100,7 @@ class Iqons {
         const accentColorString = this.colors[accentColor];
 
         /* eslint-disable max-len */
-        return TemplateTags.hasVariables(8)`<g color="${colorString}" fill="${accentColorString}">
+        return TemplateTags.hasVars(8)`<g color="${colorString}" fill="${accentColorString}">
             <rect fill="${backgroundColorString}" x="0" y="0" width="160" height="160"></rect>
             <circle cx="80" cy="80" r="40" fill="${colorString}"></circle>
             <g opacity=".1" fill="#010101"><path d="M119.21,80a39.46,39.46,0,0,1-67.13,28.13c10.36,2.33,36,3,49.82-14.28,10.39-12.47,8.31-33.23,4.16-43.26A39.35,39.35,0,0,1,119.21,80Z"/></g>
@@ -119,7 +119,7 @@ class Iqons {
     static _$svg(content) {
         const randomId = this._getRandomId();
         /* eslint-disable max-len */
-        return TemplateTags.hasVariables(3)`<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
+        return TemplateTags.hasVars(3)`<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
             <defs>
                 <clipPath id="hexagon-clip-${randomId}">
                     <path d="M251.6 17.34l63.53 110.03c5.72 9.9 5.72 22.1 0 32L251.6 269.4c-5.7 9.9-16.27 16-27.7 16H96.83c-11.43 0-22-6.1-27.7-16L5.6 159.37c-5.7-9.9-5.7-22.1 0-32L69.14 17.34c5.72-9.9 16.28-16 27.7-16H223.9c11.43 0 22 6.1 27.7 16z" transform="scale(0.5) translate(0, 16)"/>

--- a/src/lib/Iqons.js
+++ b/src/lib/Iqons.js
@@ -1,4 +1,5 @@
 /* global IqonHash */
+/* global TemplateTags */
 
 class Iqons {
     /* Public API */
@@ -26,7 +27,7 @@ class Iqons {
      */
     static async toDataUrl(text) {
         const base64string = btoa(await this.svg(text));
-        return `data:image/svg+xml;base64,${base64string.replace(/#/g, '%23')}`;
+        return TemplateTags.hasVariables(1)`data:image/svg+xml;base64,${base64string.replace(/#/g, '%23')}`;
     }
 
     /**
@@ -38,7 +39,7 @@ class Iqons {
         color = color || '#bbb';
         strokeWidth = strokeWidth || 1;
         /* eslint-disable max-len */
-        return `<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
+        return TemplateTags.hasVariables(4)`<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
             <path fill="none" stroke="${color}" stroke-width="${2 * strokeWidth}" transform="translate(0, 8) scale(0.5)" d="M251.6 17.34l63.53 110.03c5.72 9.9 5.72 22.1 0 32L251.6 269.4c-5.7 9.9-16.27 16-27.7 16H96.83c-11.43 0-22-6.1-27.7-16L5.6 159.37c-5.7-9.9-5.7-22.1 0-32L69.14 17.34c5.72-9.9 16.28-16 27.7-16H223.9c11.43 0 22 6.1 27.7 16z"/>
             <g transform="scale(0.9) translate(9, 8)">
                 <circle cx="80" cy="80" r="40" fill="none" stroke="${color}" stroke-width="${strokeWidth}" opacity=".9"></circle>
@@ -54,7 +55,7 @@ class Iqons {
      * @returns {string}
      */
     static placeholderToDataUrl(color, strokeWidth) {
-        return `data:image/svg+xml;base64,${btoa(this.placeholder(color, strokeWidth))}`;
+        return TemplateTags.hasVariables(1)`data:image/svg+xml;base64,${btoa(this.placeholder(color, strokeWidth))}`;
     }
 
     /* Private API */
@@ -99,7 +100,7 @@ class Iqons {
         const accentColorString = this.colors[accentColor];
 
         /* eslint-disable max-len */
-        return `<g color="${colorString}" fill="${accentColorString}">
+        return TemplateTags.hasVariables(8)`<g color="${colorString}" fill="${accentColorString}">
             <rect fill="${backgroundColorString}" x="0" y="0" width="160" height="160"></rect>
             <circle cx="80" cy="80" r="40" fill="${colorString}"></circle>
             <g opacity=".1" fill="#010101"><path d="M119.21,80a39.46,39.46,0,0,1-67.13,28.13c10.36,2.33,36,3,49.82-14.28,10.39-12.47,8.31-33.23,4.16-43.26A39.35,39.35,0,0,1,119.21,80Z"/></g>
@@ -118,7 +119,7 @@ class Iqons {
     static _$svg(content) {
         const randomId = this._getRandomId();
         /* eslint-disable max-len */
-        return `<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
+        return TemplateTags.hasVariables(3)`<svg viewBox="0 0 160 160" width="160" height="160" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/2000/xlink" >
             <defs>
                 <clipPath id="hexagon-clip-${randomId}">
                     <path d="M251.6 17.34l63.53 110.03c5.72 9.9 5.72 22.1 0 32L251.6 269.4c-5.7 9.9-16.27 16-27.7 16H96.83c-11.43 0-22-6.1-27.7-16L5.6 159.37c-5.7-9.9-5.7-22.1 0-32L69.14 17.34c5.72-9.9 16.28-16 27.7-16H223.9c11.43 0 22 6.1 27.7 16z" transform="scale(0.5) translate(0, 16)"/>

--- a/src/lib/TemplateTags.js
+++ b/src/lib/TemplateTags.js
@@ -1,0 +1,28 @@
+class TemplateTags {
+    // Let typescript infer return value. (Seems to be impossible to declare it the right way in standard JSDoc)
+    // eslint-disable-next-line valid-jsdoc
+    /**
+     * @template {number} T
+     * @param {T} variableCount
+     *
+     */
+    static hasVariables(variableCount) {
+        return (
+            /** @type {TemplateStringsArray} */ strings,
+            /** @type {(string | number)[] & { length: T }} */ ...expressions
+        ) => {
+            if (strings.length !== variableCount + 1) {
+                throw new Error('Illegal variable use');
+            }
+
+            let output = strings[0];
+            expressions.forEach((expression, index) => {
+                output += expression + strings[index];
+            });
+
+            return output;
+        };
+    }
+}
+
+TemplateTags.noVariables = TemplateTags.hasVariables(0);

--- a/src/lib/TemplateTags.js
+++ b/src/lib/TemplateTags.js
@@ -6,7 +6,7 @@ class TemplateTags {
      * @param {T} variableCount
      *
      */
-    static hasVariables(variableCount) {
+    static hasVars(variableCount) {
         return (
             /** @type {TemplateStringsArray} */ strings,
             /** @type {(string | number)[] & { length: T }} */ ...expressions
@@ -25,4 +25,4 @@ class TemplateTags {
     }
 }
 
-TemplateTags.noVariables = TemplateTags.hasVariables(0);
+TemplateTags.noVars = TemplateTags.hasVars(0);

--- a/src/request/change-password/index.html
+++ b/src/request/change-password/index.html
@@ -33,6 +33,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/create/IdenticonSelector.js
+++ b/src/request/create/IdenticonSelector.js
@@ -33,7 +33,7 @@ class IdenticonSelector extends Nimiq.Observable {
         $el = $el || document.createElement('div');
         $el.classList.add('identicon-selector');
 
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <div class="identicons">
                 <div class="loading center">
                     <div class="loading-animation"></div>

--- a/src/request/create/IdenticonSelector.js
+++ b/src/request/create/IdenticonSelector.js
@@ -1,6 +1,7 @@
 /* global Nimiq */
 /* global I18n */
 /* global Identicon */
+/* global TemplateTags */
 
 class IdenticonSelector extends Nimiq.Observable {
     /**
@@ -32,7 +33,7 @@ class IdenticonSelector extends Nimiq.Observable {
         $el = $el || document.createElement('div');
         $el.classList.add('identicon-selector');
 
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <div class="identicons">
                 <div class="loading center">
                     <div class="loading-animation"></div>

--- a/src/request/create/index.html
+++ b/src/request/create/index.html
@@ -32,6 +32,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/derive-address/DerivedIdenticonSelector.js
+++ b/src/request/derive-address/DerivedIdenticonSelector.js
@@ -40,7 +40,7 @@ class DerivedIdenticonSelector extends Nimiq.Observable {
         $el = $el || document.createElement('div');
         $el.classList.add('identicon-selector');
 
-        $el.innerHTML = TemplateTags.noVariables`
+        $el.innerHTML = TemplateTags.noVars`
             <div class="identicons">
                 <div class="loading center">
                     <div class="loading-animation"></div>

--- a/src/request/derive-address/DerivedIdenticonSelector.js
+++ b/src/request/derive-address/DerivedIdenticonSelector.js
@@ -2,6 +2,7 @@
 /* global I18n */
 /* global Identicon */
 /* global Errors */
+/* global TemplateTags */
 
 class DerivedIdenticonSelector extends Nimiq.Observable {
     /**
@@ -39,7 +40,7 @@ class DerivedIdenticonSelector extends Nimiq.Observable {
         $el = $el || document.createElement('div');
         $el.classList.add('identicon-selector');
 
-        $el.innerHTML = `
+        $el.innerHTML = TemplateTags.noVariables`
             <div class="identicons">
                 <div class="loading center">
                     <div class="loading-animation"></div>

--- a/src/request/derive-address/index.html
+++ b/src/request/derive-address/index.html
@@ -33,6 +33,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -33,6 +33,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -33,6 +33,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -34,6 +34,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/sign-message/index.html
+++ b/src/request/sign-message/index.html
@@ -33,6 +33,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -33,6 +33,7 @@
     <script defer bundle-toplevel src="../../lib/AnimationUtils.js"></script>
     <script defer bundle-toplevel src="../../lib/I18n.js"></script>
     <script defer bundle-toplevel src="../../lib/RequestParser.js"></script>
+    <script defer bundle-toplevel src="../../lib/TemplateTags.js"></script>
     <script defer bundle-toplevel src="../../lib/Utf8Tools.js"></script>
     <script defer bundle-toplevel src="../TopLevelApi.js"></script>
     <script defer bundle-toplevel src="../../translations/index.js"></script>


### PR DESCRIPTION
Adds template tags to template strings indicating how many variables were used.
Usage: Either e.g.
```
TemplateTags.hasVars(1)`${'foo'}bar`
```
or
```
TemplateTags.noVars`foobar`
```
If tag and actual number of variables don't match, both typescript compiler and the `hasVars` method (at runtime) will reject.
I didn't add those tags to obvious one-liners.

Tests failing with ```"An error was thrown in afterAll\nUncaught ReferenceError: TemplateTags is not defined"```, I haven't found out yet where that comes from.