### PR TITLE
Reverse test DUMMY data to fit IDB returned order

### DIFF
--- a/tests/DummyData.spec.js
+++ b/tests/DummyData.spec.js
@@ -13,21 +13,21 @@ beforeAll(async () => {
 
 const keys = [
     // eslint-disable-next-line max-len
-    Uint8Array.from([ 0x68, 0x2d, 0xf0, 0x35, 0xc3, 0x0e, 0x8c, 0x55, 0xbd, 0xa4, 0xab, 0x51, 0x72, 0x13, 0x79, 0x2c, 0x2a, 0xf4, 0xb4, 0xe9, 0xc2, 0x3a, 0xc2, 0xcf, 0x11, 0xbd, 0x28, 0xb2, 0x37, 0xa6, 0x54, 0x4e ]),
-    // eslint-disable-next-line max-len
     Uint8Array.from([ 0x50, 0x07, 0xdf, 0x4a, 0xb4, 0x57, 0x2d, 0x5c, 0x3a, 0x30, 0xbf, 0x71, 0x2b, 0xd6, 0x22, 0x37, 0x2e, 0x7a, 0x48, 0x0b, 0x6b, 0x08, 0x41, 0xf1, 0x73, 0x5c, 0x82, 0xaf, 0xf1, 0xb9, 0xa9, 0xb7 ]),
+    // eslint-disable-next-line max-len
+    Uint8Array.from([ 0x68, 0x2d, 0xf0, 0x35, 0xc3, 0x0e, 0x8c, 0x55, 0xbd, 0xa4, 0xab, 0x51, 0x72, 0x13, 0x79, 0x2c, 0x2a, 0xf4, 0xb4, 0xe9, 0xc2, 0x3a, 0xc2, 0xcf, 0x11, 0xbd, 0x28, 0xb2, 0x37, 0xa6, 0x54, 0x4e ]),
 ];
 
 const secrets = [
-    new Nimiq.PrivateKey(keys[0]),
-    new Nimiq.Entropy(keys[1]),
+    new Nimiq.Entropy(keys[0]),
+    new Nimiq.PrivateKey(keys[1]),
 ];
 
 const encryptedKeys = [
     // eslint-disable-next-line max-len
-    Uint8Array.from([ 0x03, 0x08, 0x44, 0x88, 0xd9, 0xbd, 0x82, 0xf8, 0x7b, 0x88, 0x69, 0xc4, 0xde, 0x03, 0x19, 0xe2, 0xc3, 0x95, 0xd3, 0x7d, 0x57, 0x17, 0x5a, 0x34, 0x48, 0xd2, 0x4c, 0x0d, 0xa5, 0x3d, 0xe8, 0xb4, 0x1a, 0x41, 0x13, 0xa2, 0xdc, 0xae, 0x54, 0x03, 0x0d, 0xce, 0xaf, 0x2a, 0x59, 0x10, 0xf1, 0x71, 0x7b, 0x0b, 0x2a, 0x90, 0x05, 0x6f, 0xb3, 0x46 ]),
-    // eslint-disable-next-line max-len
     Uint8Array.from([ 0x03, 0x08, 0x38, 0x8f, 0x65, 0x9f, 0x23, 0xfb, 0x80, 0x13, 0xd5, 0xef, 0x86, 0xdc, 0x4d, 0xdc, 0xd7, 0x13, 0xf4, 0x00, 0x34, 0x90, 0xe4, 0xc7, 0x9e, 0x78, 0x84, 0xa5, 0x5e, 0x21, 0x3a, 0xdb, 0x6a, 0xe1, 0x94, 0x48, 0xbd, 0x93, 0xed, 0xd1, 0x2b, 0xfd, 0x0e, 0x1f, 0x34, 0xd5, 0x4b, 0x38, 0x17, 0x4b, 0x8b, 0xf2, 0xd7, 0x4e, 0x1c, 0x10 ]),
+    // eslint-disable-next-line max-len
+    Uint8Array.from([ 0x03, 0x08, 0x44, 0x88, 0xd9, 0xbd, 0x82, 0xf8, 0x7b, 0x88, 0x69, 0xc4, 0xde, 0x03, 0x19, 0xe2, 0xc3, 0x95, 0xd3, 0x7d, 0x57, 0x17, 0x5a, 0x34, 0x48, 0xd2, 0x4c, 0x0d, 0xa5, 0x3d, 0xe8, 0xb4, 0x1a, 0x41, 0x13, 0xa2, 0xdc, 0xae, 0x54, 0x03, 0x0d, 0xce, 0xaf, 0x2a, 0x59, 0x10, 0xf1, 0x71, 0x7b, 0x0b, 0x2a, 0x90, 0x05, 0x6f, 0xb3, 0x46 ]),
 ];
 
 /** @type {string[]} */
@@ -48,17 +48,17 @@ const encryptionPassword2 = 'password2';
 const keyInfos = () => [
     new KeyInfo(
         hashes()[0],
-        Nimiq.Secret.Type.PRIVATE_KEY,
-        true,
-        false,
-        new Uint8Array(Nimiq.PublicKey.derive(new Nimiq.PrivateKey(keys[0])).toAddress().serialize()),
-    ),
-    new KeyInfo(
-        hashes()[1],
         Nimiq.Secret.Type.ENTROPY,
         false,
         false,
-        new Uint8Array(new Nimiq.Entropy(keys[1]).toExtendedPrivateKey().derivePath(Constants.DEFAULT_DERIVATION_PATH).toAddress().serialize()),
+        new Uint8Array(new Nimiq.Entropy(keys[0]).toExtendedPrivateKey().derivePath(Constants.DEFAULT_DERIVATION_PATH).toAddress().serialize()),
+    ),
+    new KeyInfo(
+        hashes()[1],
+        Nimiq.Secret.Type.PRIVATE_KEY,
+        true,
+        false,
+        new Uint8Array(Nimiq.PublicKey.derive(new Nimiq.PrivateKey(keys[1])).toAddress().serialize()),
     ),
 ];
 
@@ -72,7 +72,7 @@ const keyInfoObjects = () => keyInfos().map(x => ({
 
 const _purposeIdBuf = new Nimiq.SerialBuffer(4);
 _purposeIdBuf.writeUint32(Nimiq.Entropy.PURPOSE_ID);
-const _purposeIdArray = Array.from(_purposeIdBuf.subarray(0, 4));
+const _purposeIdArray = Array.from(_purposeIdBuf);
 
 /** @type {() => KeyRecord[]} */
 const keyRecords = () => [
@@ -80,15 +80,15 @@ const keyRecords = () => [
         id: hashes()[0],
         type: keyInfoObjects()[0].type,
         hasPin: keyInfoObjects()[0].hasPin,
-        secret: encryptedKeys[0],
-        defaultAddress: keyInfos()[0].defaultAddress.serialize().subarray(0, 20),
+        secret: new Uint8Array(_purposeIdArray.concat(Array.from(keys[0]))),
+        defaultAddress: new Uint8Array(keyInfos()[0].defaultAddress.serialize()),
     },
     {
         id: hashes()[1],
         type: keyInfoObjects()[1].type,
         hasPin: keyInfoObjects()[1].hasPin,
-        secret: new Uint8Array(_purposeIdArray.concat(Array.from(keys[1]))),
-        defaultAddress: keyInfos()[1].defaultAddress.serialize().subarray(0, 20),
+        secret: encryptedKeys[1],
+        defaultAddress: new Uint8Array(keyInfos()[1].defaultAddress.serialize()),
     },
 ];
 
@@ -109,11 +109,11 @@ const deprecatedAccountCookies = [
 ];
 
 const deprecatedAccountRecords = [
-    Object.assign({}, deprecatedAccountInfos[0], { encryptedKeyPair: encryptedKeys[0] }),
+    Object.assign({}, deprecatedAccountInfos[0], { encryptedKeyPair: encryptedKeys[1] }),
 ];
 
 const deprecatedAccount2KeyInfoObjects = () => [{
-    id: hashes()[0],
+    id: hashes()[1],
     type: Nimiq.Secret.Type.PRIVATE_KEY,
     hasPin: false,
     legacyAccount: {
@@ -122,7 +122,7 @@ const deprecatedAccount2KeyInfoObjects = () => [{
     },
 }];
 
-const keyInfoCookieEncoded = '10LsYVUikGJA5z8p37+LqkH3EZ5opDz2zQRT1r8cGJ8dE=,2071U/NKd5KzeimvyflGLYku6JfI9Mms2wGxWoCLmx9+0=';
+const keyInfoCookieEncoded = '2071U/NKd5KzeimvyflGLYku6JfI9Mms2wGxWoCLmx9+0=,10LsYVUikGJA5z8p37+LqkH3EZ5opDz2zQRT1r8cGJ8dE=';
 
 /** @type {string} */
 const cookie = `k=${keyInfoCookieEncoded};accounts=${JSON.stringify(deprecatedAccountCookies)};some=thing;`;

--- a/tests/lib/IframeApi.spec.js
+++ b/tests/lib/IframeApi.spec.js
@@ -62,7 +62,7 @@ describe('IframeApi', () => {
         expect(CookieJar.eat).not.toHaveBeenCalled();
         expect(AccountStore.instance.list).not.toHaveBeenCalled();
         expect(KeyStore.instance.list).toHaveBeenCalled();
-        expect(listedKeyObjects).toEqual(Dummy.keyInfoObjects().reverse());
+        expect(listedKeyObjects).toEqual(Dummy.keyInfoObjects());
 
         await Dummy.Utils.deleteDummyKeyStore();
     });

--- a/tests/lib/Key.spec.js
+++ b/tests/lib/Key.spec.js
@@ -4,8 +4,8 @@
 
 describe('Key', () => {
     it('can sign a message (LEGACY)', () => {
-        const key = new Key(Dummy.secrets[0]);
-        const pubkey = Nimiq.PublicKey.derive(Dummy.secrets[0]);
+        const key = new Key(Dummy.secrets[1]);
+        const pubkey = Nimiq.PublicKey.derive(Dummy.secrets[1]);
         const data = Nimiq.BufferUtils.fromAscii('hello');
         const signedData = Nimiq.BufferUtils.fromAscii('\x16Nimiq Signed Message:\n5hello');
         const hashedSignedData = Nimiq.Hash.computeSha256(signedData);
@@ -20,7 +20,7 @@ describe('Key', () => {
     });
 
     it('can sign a message (BIP39)', () => {
-        const key = new Key(Dummy.secrets[1]);
+        const key = new Key(Dummy.secrets[0]);
         const data = new Nimiq.SerialBuffer([1, 2, 3, 4, 5, 6]);
         const signedData = new Uint8Array(
             Array.from(Nimiq.BufferUtils.fromAscii('\x16Nimiq Signed Message:\n6')).concat([1, 2, 3, 4, 5, 6]),
@@ -39,14 +39,14 @@ describe('Key', () => {
     });
 
     it('can derive addresses (LEGACY)', () => {
-        const key = new Key(Dummy.secrets[0]);
+        const key = new Key(Dummy.secrets[1]);
         const address = 'NQ71 CT4K 7R9R EHSB 7HY9 TSTP XNRQ L2RK 8U4U';
         expect(key.deriveAddress('m').toUserFriendlyAddress()).toEqual(address);
         expect(key.deriveAddress('m/0\'').toUserFriendlyAddress()).toEqual(address);
     });
 
     it('can derive addresses (BIP39)', () => {
-        const key = new Key(Dummy.secrets[1]);
+        const key = new Key(Dummy.secrets[0]);
         const address1 = 'NQ46 2RM7 QE4T 82KR 61Q9 9B7E R38G LBVM N6KY';
         const address2 = 'NQ70 APBA 9GCC FL44 D82R UJCD DS4B Y824 3LYJ';
         expect(key.deriveAddress('m').toUserFriendlyAddress()).toEqual(address1);

--- a/tests/lib/KeyStore.spec.js
+++ b/tests/lib/KeyStore.spec.js
@@ -33,8 +33,8 @@ describe('KeyStore', () => {
 
     it('can get and decrypt keys', async () => {
         const keys = await Promise.all([
-            KeyStore.instance.get(Dummy.keyInfos()[0].id, Nimiq.BufferUtils.fromAscii(Dummy.encryptionPassword)),
-            KeyStore.instance.get(Dummy.keyInfos()[1].id),
+            KeyStore.instance.get(Dummy.keyInfos()[0].id),
+            KeyStore.instance.get(Dummy.keyInfos()[1].id, Nimiq.BufferUtils.fromAscii(Dummy.encryptionPassword)),
         ]);
 
         for (let [i, key] of keys.entries()) {
@@ -48,12 +48,12 @@ describe('KeyStore', () => {
 
     it('can list keys', async () => {
         const keyInfos = await KeyStore.instance.list();
-        expect(keyInfos).toEqual(Dummy.keyInfos().reverse());
+        expect(keyInfos).toEqual(Dummy.keyInfos());
     });
 
     it('can remove keys', async () => {
         let currentKeys = await KeyStore.instance.list();
-        expect(currentKeys).toEqual(Dummy.keyInfos().reverse());
+        expect(currentKeys).toEqual(Dummy.keyInfos());
 
         await KeyStore.instance.remove(Dummy.keyInfos()[0].id);
         currentKeys = await KeyStore.instance.list();
@@ -83,24 +83,24 @@ describe('KeyStore', () => {
         // add an encrypted key
         const password = Nimiq.BufferUtils.fromAscii(Dummy.encryptionPassword);
         await KeyStore.instance.put(new Key(
-            Dummy.secrets[0],
-            Dummy.keyInfos()[0].hasPin,
+            Dummy.secrets[1],
+            Dummy.keyInfos()[1].hasPin,
         ), password);
         currentKeys = await KeyStore.instance.list();
         expect(currentKeys.length).toBe(1);
 
         // add a plain key
         await KeyStore.instance.put(new Key(
-            Dummy.secrets[1],
-            Dummy.keyInfos()[1].hasPin,
+            Dummy.secrets[0],
+            Dummy.keyInfos()[0].hasPin,
         ));
         currentKeys = await KeyStore.instance.list();
-        expect(currentKeys).toEqual(Dummy.keyInfos().reverse());
+        expect(currentKeys).toEqual(Dummy.keyInfos());
 
         // check that the keys have been stored correctly
         const [key1, key2] = await Promise.all([
-            KeyStore.instance.get(Dummy.keyInfos()[0].id, password),
-            KeyStore.instance.get(Dummy.keyInfos()[1].id),
+            KeyStore.instance.get(Dummy.keyInfos()[0].id),
+            KeyStore.instance.get(Dummy.keyInfos()[1].id, password),
         ]);
         if (!key1 || !key2) throw new Error();
         expect(key1.secret.equals(Dummy.secrets[0])).toBe(true);
@@ -127,8 +127,8 @@ describe('KeyStore', () => {
         await KeyStore.instance.migrateAccountsToKeys();
 
         expect(cookieSet).toBe(false);
-        const key1 = await KeyStore.instance._get(Dummy.keyInfos()[0].id);
-        expect(key1).toEqual(Dummy.keyRecords()[0]);
+        const key1 = await KeyStore.instance._get(Dummy.keyInfos()[1].id);
+        expect(key1).toEqual(Dummy.keyRecords()[1]);
 
         const accountsDbAfter = await AccountStore.instance.connect();
         expect(accountsDbAfter).toBe(null);
@@ -163,8 +163,8 @@ describe('KeyStore', () => {
         await KeyStore.instance.migrateAccountsToKeys();
 
         expect(migrationCookieDeleted && accountsCookieDeleted).toBe(true);
-        const key1 = await KeyStore.instance._get(Dummy.keyInfos()[0].id);
-        expect(key1).toEqual(Dummy.keyRecords()[0]);
+        const key1 = await KeyStore.instance._get(Dummy.keyInfos()[1].id);
+        expect(key1).toEqual(Dummy.keyRecords()[1]);
 
         const accountsDb = await AccountStore.instance.connect();
         expect(accountsDb).toBe(null);


### PR DESCRIPTION
Following the comments at https://github.com/nimiq/keyguard-next/pull/255#discussion_r275251683, this PR reverses the DUMMY key order to get rid of `reverse()` calls.

This PR only concerns tests.