### PR TITLE
Skip Buttons

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -292,29 +292,30 @@ body.loading .page:target .page-footer > .loading-spinner {
 }
 
 .skip {
-    font-size: 1.625rem;
+    display: block;
+    font-size: 1.75rem;
+    font-weight: 600;
     line-height: 2;
+    text-align: center;
     color: inherit;
     cursor: pointer;
-    display: flex;
-    align-items: baseline;
-    justify-content: center;
     margin: -1.25rem auto 0;
-    width:40%;
-    align-self: center;
+    width: 40%;
+    opacity: 0.7;
+    transition: opacity .3s ease;
 }
 
 .skip .nq-icon  {
-    margin-left: 0.5rem;
-    height: 0.875rem;
-    width: 0.875rem;
+    height: 1.25rem;
+    width: 1.25rem;
     transition: transform .3s ease;
+    vertical-align: middle;
 }
 
 .skip:hover,
 .skip:focus {
     outline: none;
-    opacity: 0.7;
+    opacity: 1;
     text-decoration: none;
 }
 

--- a/src/common.css
+++ b/src/common.css
@@ -290,3 +290,40 @@ body.loading .page:target .page-footer > .loading-spinner {
 .nq-notice {
     font-size: 2rem;
 }
+
+.skip {
+    font-size: 1.625rem;
+    line-height: 2;
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    margin: -1.25rem auto 0;
+    width:40%;
+    align-self: center;
+}
+
+.skip .nq-icon  {
+    margin-left: 0.5rem;
+    height: 0.875rem;
+    width: 0.875rem;
+    transition: transform .3s ease;
+}
+
+.skip:hover,
+.skip:focus {
+    outline: none;
+    opacity: 0.7;
+    text-decoration: none;
+}
+
+.skip:hover .nq-icon,
+.skip:focus .nq-icon {
+    transform: translate3D(-0.25rem, 0, 0);
+}
+
+.nq-card > .skip {
+    margin-top: -3.25rem;
+    margin-bottom: 1rem;
+}

--- a/src/components/PasswordBox.css
+++ b/src/components/PasswordBox.css
@@ -109,39 +109,10 @@
     color: var(--nimiq-red);
 }
 
-.password-box.input-eligible .password-skip,
 .password-box.repeat.repeat-short .repeat-password,
 .password-box.repeat.repeat-long .repeat-password {
     opacity: 0;
     pointer-events: none;
-}
-
-.password-box .password-skip {
-    transition: opacity 300ms;
-    cursor: pointer;
-    display: block;
-    font-size: 1.625rem;
-    transition: opacity .3s ease;
-    position: absolute;
-    bottom: 1rem;
-    width: calc(100% - 2.5rem);
-}
-
-.password-box .password-skip .nq-icon {
-    font-size: 1.375rem;
-    margin-bottom: -0.125rem;
-    transition: transform .3s ease;
-}
-
-.password-box .password-skip:hover,
-.password-box .password-skip:focus {
-    outline: none;
-    opacity: 0.7;
-}
-
-.password-box .password-skip:hover .nq-icon,
-.password-box .password-skip:focus .nq-icon {
-    transform: translate3D(-0.25rem, 0, 0);
 }
 
 .password-box.repeat .repeat-password {
@@ -149,7 +120,6 @@
 }
 
 .password-box.repeat .password-hint,
-.password-box.repeat .password-skip,
 .password-box.repeat .password-strength {
     visibility: hidden;
 }

--- a/src/components/PasswordSetterBox.js
+++ b/src/components/PasswordSetterBox.js
@@ -13,7 +13,6 @@ class PasswordSetterBox extends Nimiq.Observable {
     constructor($el, options = {}) {
         const defaults = {
             bgColor: 'light-blue',
-            hideSkip: false,
         };
 
         super();
@@ -30,10 +29,6 @@ class PasswordSetterBox extends Nimiq.Observable {
 
         this.$el.addEventListener('submit', event => this._onSubmit(event));
 
-        if (!options.hideSkip) {
-            /** @type {HTMLElement} */
-            (this.$el.querySelector('.password-skip')).addEventListener('click', () => this._onSkip());
-        }
 
         this._onInputChangeValidity(false);
 
@@ -55,7 +50,7 @@ class PasswordSetterBox extends Nimiq.Observable {
         $el.classList.add('password-box', 'actionbox', 'setter', `nq-${options.bgColor}-bg`);
 
         /* eslint-disable max-len */
-        $el.innerHTML = TemplateTags.hasVars(1)`
+        $el.innerHTML = TemplateTags.noVars`
             <div class="password-strength strength-short  nq-text-s" data-i18n="passwordbox-password-strength-short" >Enter at least 8 characters</div>
             <div class="password-strength strength-weak   nq-text-s" data-i18n="passwordbox-password-strength-weak"  >That is a weak password</div>
             <div class="password-strength strength-good   nq-text-s" data-i18n="passwordbox-password-strength-good"  >Ok, that is an average password</div>
@@ -69,14 +64,6 @@ class PasswordSetterBox extends Nimiq.Observable {
 
             <button class="submit" data-i18n="passwordbox-repeat">Repeat password</button>
 
-            ${options.hideSkip ? '' : TemplateTags.noVars`
-                <a tabindex="0" class="password-skip nq-text-s">
-                    <span data-i18n="passwordbox-password-skip">Skip for now</span>
-                    <svg class="nq-icon">
-                        <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
-                    </svg>
-                </a>
-            `}
             <svg height="48" width="54" color="inherit" class="loading-spinner">
                 <use xlink:href="#loading-spinner" />
             </svg>
@@ -209,16 +196,10 @@ class PasswordSetterBox extends Nimiq.Observable {
             await AnimationUtils.animate('shake', this._passwordInput.$el);
         }
     }
-
-    _onSkip() {
-        this.fire(PasswordSetterBox.Events.SKIP);
-        this.reset();
-    }
 }
 
 PasswordSetterBox.Events = {
     SUBMIT: 'passwordbox-submit',
     ENTERED: 'passwordbox-entered',
     RESET: 'passsordbox-reset',
-    SKIP: 'passwordbox-skip',
 };

--- a/src/components/ValidateWords.css
+++ b/src/components/ValidateWords.css
@@ -78,15 +78,3 @@
 .validate-words .back-to-words {
     cursor: pointer;
 }
-
-.validate-words .skip-container {
-    margin-top: 4.5rem;
-    text-align: center;
-}
-
-.validate-words .skip {
-    font-size: 1.625rem;
-    color: inherit;
-    cursor: pointer;
-    text-align: center;
-}

--- a/src/components/ValidateWords.js
+++ b/src/components/ValidateWords.js
@@ -27,11 +27,6 @@ class ValidateWords extends Nimiq.Observable {
         this.$el.addEventListener('click', this._onClick.bind(this));
         /** @type {HTMLElement} */
         this.$textHint = (this.$el.querySelector('p'));
-
-        /** @type {HTMLFormElement} */
-        const $skip = (this.$el.querySelector('.skip'));
-
-        $skip.addEventListener('click', () => this.fire(ValidateWords.Events.SKIP));
     }
 
     /**
@@ -54,13 +49,6 @@ class ValidateWords extends Nimiq.Observable {
                 <button class="nq-button light-blue"></button>
                 <button class="nq-button light-blue"></button>
             </div>
-            <div class="flex-grow"></div>
-            <a class="skip nq-text-s">
-                <span data-i18n="passwordbox-password-skip">Skip for now</span>
-                <svg class="nq-icon">
-                    <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
-                </svg>
-            </a>
         `;
         /* eslint-enable max-len */
 
@@ -237,7 +225,6 @@ class ValidateWords extends Nimiq.Observable {
 }
 
 ValidateWords.Events = {
-    SKIP: 'validate-words-skip',
     VALIDATED: 'validate-words-validated',
     BACK: 'validate-words-back',
 };

--- a/src/request/change-password/ChangePassword.js
+++ b/src/request/change-password/ChangePassword.js
@@ -50,6 +50,8 @@ class ChangePassword {
         this.$setPasswordBackButton = ($setPassword.querySelector('a.page-header-back-button'));
         /** @type {HTMLAnchorElement} */
         const $downloadLoginFile = ($downloadFile.querySelector('.download-login-file'));
+        /** @type {HTMLLinkElement} */
+        const $skipDownloadButton = ($downloadFile.querySelector('.skip'));
 
         // Components
         this._passwordSetter = new PasswordSetterBox($passwordSetter);
@@ -95,10 +97,13 @@ class ChangePassword {
         this._passwordGetter.on(PasswordBox.Events.SUBMIT, this._unlock.bind(this));
         this._passwordSetter.on(PasswordSetterBox.Events.ENTERED, this._prepare.bind(this));
         this._passwordSetter.on(PasswordSetterBox.Events.SUBMIT, this._commitChangeAndOfferLoginFile.bind(this));
-        this._passwordSetter.on(PasswordSetterBox.Events.SKIP, this._commitChangeAndOfferLoginFile.bind(this));
         this._passwordSetter.on(PasswordSetterBox.Events.RESET, this.backToEnterPassword.bind(this));
 
         this._downloadLoginFile.on(DownloadLoginFile.Events.DOWNLOADED, () => {
+            this._resolve({ success: true });
+        });
+        $skipDownloadButton.addEventListener('click', e => {
+            e.preventDefault();
             this._resolve({ success: true });
         });
     }
@@ -166,7 +171,7 @@ class ChangePassword {
 
     /**
      * Called after new password was entered second time.
-     * @param {string} [newPassword]
+     * @param {string} newPassword
      */
     async _commitChangeAndOfferLoginFile(newPassword) {
         TopLevelApi.setLoading(true);

--- a/src/request/change-password/index.html
+++ b/src/request/change-password/index.html
@@ -147,6 +147,14 @@
             <div class="page-body nq-card-body">
                 <a class="download-login-file"></a>
             </div>
+
+            <a href="#" class="skip nq-link">
+                <span data-i18n="passwordbox-password-skip">Skip for now</span>
+                <svg class="nq-icon">
+                    <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
+                </svg>
+            </a>
+
         </div>
 
         <button class="global-close nq-button-s display-none">

--- a/src/request/create/Create.js
+++ b/src/request/create/Create.js
@@ -80,11 +80,6 @@ class Create {
             this.finish(request);
         });
 
-        this._passwordSetter.on(PasswordSetterBox.Events.SKIP, () => {
-            this.progressIndicator.setStep(3);
-            this.finish(request);
-        });
-
         this._passwordSetter.on(PasswordSetterBox.Events.ENTERED, () => {
             this.$setPasswordPage.classList.add('repeat-password');
             this.progressIndicator.setStep(3);

--- a/src/request/export/Export.css
+++ b/src/request/export/Export.css
@@ -222,43 +222,6 @@ ul.nq-list li > .nq-icon {
     text-align: center;
 }
 
-.password-box:not(.hide-input) + .skip-words {
-    position: absolute;
-    width: calc(100% - 2rem);
-    bottom: 2.25rem;
-}
-
-.password-box:not(.hide-input).input-eligible + .skip-words {
-    display: none;
-}
-
 .page-footer {
     padding: 1rem;
-}
-
-.skip-words {
-    cursor: pointer;
-    display: block;
-    text-align: center;
-    font-size: 1.625rem;
-    transition: opacity .3s ease;
-}
-
-.skip .nq-icon,
-.skip-words .nq-icon {
-    margin-left: 0.5rem;
-    height: 0.875rem;
-    width: 0.875rem;
-    transition: transform .3s ease;
-}
-
-.skip-words:hover,
-.skip-words:focus {
-    outline: none;
-    opacity: 0.7;
-}
-
-.skip-words:hover .nq-icon,
-.skip-words:focus .nq-icon {
-    transform: translate3D(-0.25rem, 0, 0);
 }

--- a/src/request/export/Export.js
+++ b/src/request/export/Export.js
@@ -48,7 +48,7 @@ class Export {
         this._fileSuccessPage = (document.getElementById(Export.Pages.LOGIN_FILE_SUCCESS));
 
         /** @type {HTMLLinkElement} */
-        const skipWordsButton = (this._fileSuccessPage.querySelector('.skip-words'));
+        const skipWordsButton = (this._fileSuccessPage.querySelector('.skip'));
         skipWordsButton.addEventListener('click', e => {
             e.preventDefault();
             this._resolve(this.exported);

--- a/src/request/export/ExportFile.js
+++ b/src/request/export/ExportFile.js
@@ -66,11 +66,7 @@ class ExportFile extends Nimiq.Observable {
                 hideCancel: true,
             },
         );
-        this._passwordSetterBox = new PasswordSetterBox(
-            $passwordSetterBox, {
-                hideSkip: true,
-            },
-        );
+        this._passwordSetterBox = new PasswordSetterBox($passwordSetterBox);
         this._loginFileIcon = new LoginFileIcon($loginFileIcon);
         this._downloadLoginFile = new DownloadLoginFile($downloadLoginFile);
         this._downloadLoginFile.createDummyFile(this._request.keyInfo.defaultAddress);

--- a/src/request/export/ExportWords.js
+++ b/src/request/export/ExportWords.js
@@ -44,14 +44,10 @@ class ExportWords extends Nimiq.Observable {
         const $validateWordsPage = (document.getElementById(ExportWords.Pages.VALIDATE_WORDS));
 
         // elements
-        /** @type {HTMLLinkElement} */
-        const $noRecoverySkip = (this._$noRecoveryPage.querySelector('.skip-words'));
         /** @type {HTMLFormElement} */
         const $wordsPasswordBox = (this._$noRecoveryPage.querySelector('.password-box'));
         /** @type {HTMLElement} */
         const $recoveryWords = ($recoveryWordsPage.querySelector('.recovery-words'));
-        /** @type {HTMLLinkElement} */
-        const $recoveryWordsSkip = ($recoveryWordsPage.querySelector('.skip-words'));
         /** @type {HTMLButtonElement} */
         const $recoveryWordsContinue = ($recoveryWordsPage.querySelector('button'));
         /** @type {HTMLElement} */
@@ -72,21 +68,12 @@ class ExportWords extends Nimiq.Observable {
         /* eslint-enable no-new */
 
         // events
-        $noRecoverySkip.addEventListener('click', event => {
-            event.preventDefault();
-            this._resolve({ success: false });
-        });
-        $recoveryWordsSkip.addEventListener('click', event => {
-            event.preventDefault();
-            this._resolve({ success: false });
-        });
         this._wordsPasswordBox.on(PasswordBox.Events.SUBMIT, this._passwordSubmitted.bind(this));
         $recoveryWordsContinue.addEventListener('click', () => {
             this._validateWords.reset();
             window.location.hash = ExportWords.Pages.VALIDATE_WORDS;
         });
         this._validateWords.on(ValidateWords.Events.VALIDATED, () => this._resolve({ success: true }));
-        this._validateWords.on(ValidateWords.Events.SKIP, () => this._resolve({ success: false }));
     }
 
     run() {

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -138,12 +138,6 @@
 
                 <div class="page-footer">
                     <form class="password-box"></form>
-                    <a class="skip-words nq-text-s">
-                        <span data-i18n="passwordbox-password-skip">Skip for now</span>
-                        <svg class="nq-icon">
-                            <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
-                        </svg>
-                    </a>
                 </div>
             </div>
 
@@ -177,12 +171,6 @@
 
                 <div class="page-footer">
                     <button class="to-validate-words nq-button light-blue" data-i18n="recovery-words-validate">Validate words</button>
-                    <a href="#" class="skip-words nq-link nq-text-s nq-blue">
-                        <span data-i18n="passwordbox-password-skip">Skip for now</span>
-                        <svg class="nq-icon">
-                            <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
-                        </svg>
-                    </a>
                 </div>
             </div>
 
@@ -301,7 +289,7 @@
 
                 <div class="page-footer">
                     <button data-i18n="go-to-recovery-words" class="nq-button recovery-words-button light-blue">Create backup</button>
-                    <a href="#" class="skip-words nq-link nq-text-s nq-blue">
+                    <a href="#" class="skip nq-link">
                         <span data-i18n="passwordbox-password-skip">Skip for now</span>
                         <svg class="nq-icon">
                             <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>

--- a/src/request/import/Import.css
+++ b/src/request/import/Import.css
@@ -126,21 +126,7 @@ button#goto-words {
 }
 
 a#goto-create {
-    font-size: 1.75rem;
-    text-decoration: none;
-    margin: 2rem 0;
-    opacity: 0.7;
-    transition: opacity 0.3s ease;
-}
-
-a#goto-create .nq-icon {
-    font-size: 1.375rem;
-    margin-bottom: -0.125rem;
-}
-
-a#goto-create:hover,
-a#goto-create:focus {
-    opacity: 1;
+    margin: 1.25rem 0;
 }
 
 .page#set-password .page-body {

--- a/src/request/import/ImportWords.js
+++ b/src/request/import/ImportWords.js
@@ -60,6 +60,8 @@ class ImportWords {
         const $loginFileIcon = (this.$setPassword.querySelector('.login-file-icon'));
         /** @type {HTMLAnchorElement} */
         const $downloadLoginFile = ($downloadFile.querySelector('.download-loginfile'));
+        /** @type {HTMLLinkElement} */
+        const $skipDownloadButton = ($downloadFile.querySelector('.skip'));
 
         // Components
         this._recoveryWords = new RecoveryWords($recoveryWords, true);
@@ -128,8 +130,8 @@ class ImportWords {
             window.location.hash = ImportWords.Pages.DOWNLOAD_LOGINFILE;
         });
 
-        this._passwordSetter.on(PasswordSetterBox.Events.SKIP, async () => {
-            await this._storeKeys();
+        $skipDownloadButton.addEventListener('click', e => {
+            e.preventDefault();
             this._resolve(this._keyResults);
         });
 

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -162,7 +162,7 @@
                     <button data-i18n="import-file-button-words" class="nq-button-s" id="goto-words">
                         Login with Recovery Words
                     </button>
-                    <a class="nq-text-s nq-blue" id="goto-create" href="#">
+                    <a class="skip nq-link" id="goto-create" href="#">
                         <span data-i18n="import-create-account">Create new account</span>
                         <svg class="nq-icon"><use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/></svg>
                     </a>

--- a/src/request/import/index.html
+++ b/src/request/import/index.html
@@ -139,6 +139,13 @@
                 <div class="page-body nq-card-body">
                     <a class="download-loginfile"></a>
                 </div>
+
+                <a href="#" class="skip nq-link">
+                    <span data-i18n="passwordbox-password-skip">Skip for now</span>
+                    <svg class="nq-icon">
+                        <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
+                    </svg>
+                </a>
             </div>
 
             <div id="import-file" class="page nq-card">

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -191,12 +191,6 @@
 
                 <div class="page-footer">
                     <form class="password-box"></form>
-                    <a class="skip-words nq-text-s">
-                        <span data-i18n="passwordbox-password-skip">Skip for now</span>
-                        <svg class="nq-icon">
-                            <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
-                        </svg>
-                    </a>
                 </div>
             </div>
 
@@ -230,12 +224,6 @@
 
                 <div class="page-footer">
                     <button class="to-validate-words nq-button light-blue" data-i18n="continue">Continue</button>
-                    <a href="#" class="skip-words nq-link nq-text-s nq-blue">
-                        <span data-i18n="passwordbox-password-skip">Skip for now</span>
-                        <svg class="nq-icon">
-                            <use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-caret-right-small"/>
-                        </svg>
-                    </a>
                 </div>
             </div>
 


### PR DESCRIPTION
Skip buttons now only appear on:

- change-password's file download page to skip the download of the file
- login's file download page after word import to skip the download of the file
- complete export's file-completed page to skip recovery words

Styles for the skip button are moved to common.css.