### PR TITLE
Hide the Login File option for Private Keys in remove-key

### DIFF
--- a/src/request/remove-key/RemoveKey.js
+++ b/src/request/remove-key/RemoveKey.js
@@ -1,6 +1,7 @@
 /* global ExportWords */
 /* global ExportFile */
 /* global KeyStore */
+/* global Nimiq */
 /* global TopLevelApi */
 /* global Constants */
 /* global IqonHash */
@@ -45,11 +46,16 @@ class RemoveKey {
         /** @type {HTMLButtonElement} */
         const $finalConfirmButton = ($removeKey.querySelector('#remove-key-final-confirm'));
 
-        const color = IqonHash.getBackgroundColorIndex(
-            request.keyInfo.defaultAddress.toUserFriendlyAddress(),
-        );
-        const colorClass = LoginFile.CONFIG[color].className;
-        $loginFileContainer.classList.add(colorClass);
+        if (request.keyInfo.type === Nimiq.Secret.Type.PRIVATE_KEY) {
+            /** @type {HTMLElement} */
+            ($removeKey.querySelector('.backup-option.login-file')).classList.add('display-none');
+        } else {
+            const color = IqonHash.getBackgroundColorIndex(
+                request.keyInfo.defaultAddress.toUserFriendlyAddress(),
+            );
+            const colorClass = LoginFile.CONFIG[color].className;
+            $loginFileContainer.classList.add(colorClass);
+        }
 
         $labelSpan.textContent = this._request.keyLabel;
 

--- a/src/request/remove-key/index.html
+++ b/src/request/remove-key/index.html
@@ -105,7 +105,7 @@
                 </div>
 
                 <div class="page-body nq-card-body">
-                    <div class="backup-option">
+                    <div class="backup-option login-file">
                         <div class="login-file-svg-container">
                             <img src="../../assets/dummy-login-file.svg">
                         </div>
@@ -119,7 +119,7 @@
                             </button>
                         </div>
                     </div>
-                    <div class="backup-option">
+                    <div class="backup-option recovery-words">
                         <img src="../../assets/sample-recovery-words.png" alt="sample recovery words" />
                         <div>
                             <div class="question" data-i18n="remove-key-recovery-words-question">


### PR DESCRIPTION
For now just removes it, as the flow itself will result in an error, since Private Keys cannot be exported to a Login File.

Should be improved upon in the future i.e. display something in its place instead.