### PR TITLE
Client: handle history back

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.5.0-beta.1",
+  "version": "0.5.0-beta.2",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nimiq/keyguard-next/client#readme",
   "dependencies": {
-    "@nimiq/rpc": "^0.2.0-beta.2",
+    "@nimiq/rpc": "^0.2.0-beta.3",
     "@nimiq/core-web": "1.4.3"
   },
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.4.3",
+  "version": "0.5.0-beta.1",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nimiq/keyguard-next/client#readme",
   "dependencies": {
-    "@nimiq/rpc": "^0.1.4",
+    "@nimiq/rpc": "^0.2.0-beta.2",
     "@nimiq/core-web": "1.4.3"
   },
   "devDependencies": {

--- a/client/src/KeyguardClient.ts
+++ b/client/src/KeyguardClient.ts
@@ -52,9 +52,10 @@ export class KeyguardClient {
         returnURL?: string,
         localState?: ObjectType|null,
         preserveRequests?: boolean,
+        handleHistoryBack?: boolean,
     ) {
         this._endpoint = endpoint;
-        this._redirectBehavior = new RedirectRequestBehavior(returnURL, localState);
+        this._redirectBehavior = new RedirectRequestBehavior(returnURL, localState, handleHistoryBack);
         this._iframeBehavior = new IFrameRequestBehavior();
 
         // If this is a page-reload, allow location.origin as RPC origin

--- a/client/src/RequestBehavior.ts
+++ b/client/src/RequestBehavior.ts
@@ -35,12 +35,14 @@ export class RedirectRequestBehavior extends RequestBehavior {
 
     private readonly _returnUrl: string;
     private readonly _localState: ObjectType|null;
+    private readonly _handleHistoryBack: boolean;
 
-    constructor(returnUrl?: string, localState?: ObjectType|null) {
+    constructor(returnUrl?: string, localState?: ObjectType|null, handleHistoryBack = false) {
         super(BehaviorType.REDIRECT);
         const location = window.location;
         this._returnUrl = returnUrl || `${location.origin}${location.pathname}`;
         this._localState = localState || {};
+        this._handleHistoryBack = handleHistoryBack;
 
         // Reject local state with reserved property.
         if (typeof this._localState.__command !== 'undefined') {
@@ -55,7 +57,7 @@ export class RedirectRequestBehavior extends RequestBehavior {
         const client = new RedirectRpcClient(url, allowedOrigin);
 
         const state = Object.assign({ __command: command }, this._localState);
-        client.callAndSaveLocalState(this._returnUrl, state, 'request', ...args);
+        client.callAndSaveLocalState(this._returnUrl, state, 'request', this._handleHistoryBack, ...args);
     }
 }
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.4.3.tgz#190d7390324623672fafbbc93841bcf215d2af01"
   integrity sha512-47JMAx8bFcr2uev+QgX4saBUvRQo/8akQdpvf0z1F5N3I8FPyIfEWRjPW2Xu28C+MOdIZ/VkHL/YmMiGBBtEMA==
 
-"@nimiq/rpc@^0.2.0-beta.2":
-  version "0.2.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.2.0-beta.2.tgz#61b090f5b1587eb53d47c88c61493904815d514e"
-  integrity sha512-jOh+qjGLQ9J/YvxMWtNFlPHHPkqB7DB5wn85yZLqiQbXhLGl/oyB6jciBfsAG1jUt9eNhNoarb4u8yRPcMXNzw==
+"@nimiq/rpc@^0.2.0-beta.3":
+  version "0.2.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.2.0-beta.3.tgz#9c6b54d8cbf209511424563eab62cdf4cbf61878"
+  integrity sha512-bCTqXG496VrhbP/GQkZoPu32pQbN++HZ7j6TR/6qIVuWnA5/S7o9ZHYrdRfT0Ebiw6qz/z8csn34kDNb19+W+A==
 
 "@types/estree@0.0.39":
   version "0.0.39"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.4.3.tgz#190d7390324623672fafbbc93841bcf215d2af01"
   integrity sha512-47JMAx8bFcr2uev+QgX4saBUvRQo/8akQdpvf0z1F5N3I8FPyIfEWRjPW2Xu28C+MOdIZ/VkHL/YmMiGBBtEMA==
 
-"@nimiq/rpc@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.1.4.tgz#ff6608255f23bb80079e10b23b7b74c35190e9da"
-  integrity sha512-vKU8zw8aHabGBaRTvf31MeVaByhkEChkdlx6IYw555XH5TitYQO6XYfTpoDelXUOG/xX4BQrCMV6NnLKY5yN0Q==
+"@nimiq/rpc@^0.2.0-beta.2":
+  version "0.2.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.2.0-beta.2.tgz#61b090f5b1587eb53d47c88c61493904815d514e"
+  integrity sha512-jOh+qjGLQ9J/YvxMWtNFlPHHPkqB7DB5wn85yZLqiQbXhLGl/oyB6jciBfsAG1jUt9eNhNoarb4u8yRPcMXNzw==
 
 "@types/estree@0.0.39":
   version "0.0.39"


### PR DESCRIPTION
Add an optional `handleHistoryBack` boolean flag to the KeyguardClient constructor, to forward the wanted behavior to the RPC client.

Based on https://github.com/nimiq/rpc/pull/18.