### PR TITLE
Update RpcServer to handle request in fragment

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/nimiq/keyguard-next/client#readme",
   "dependencies": {
-    "@nimiq/rpc": "^0.2.0-beta.3",
+    "@nimiq/rpc": "^0.2.1",
     "@nimiq/core-web": "1.4.3"
   },
   "devDependencies": {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.4.3.tgz#190d7390324623672fafbbc93841bcf215d2af01"
   integrity sha512-47JMAx8bFcr2uev+QgX4saBUvRQo/8akQdpvf0z1F5N3I8FPyIfEWRjPW2Xu28C+MOdIZ/VkHL/YmMiGBBtEMA==
 
-"@nimiq/rpc@^0.2.0-beta.3":
-  version "0.2.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.2.0-beta.3.tgz#9c6b54d8cbf209511424563eab62cdf4cbf61878"
-  integrity sha512-bCTqXG496VrhbP/GQkZoPu32pQbN++HZ7j6TR/6qIVuWnA5/S7o9ZHYrdRfT0Ebiw6qz/z8csn34kDNb19+W+A==
+"@nimiq/rpc@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.2.1.tgz#f39a782eafc7dc8b67e306b85845f114fcd3a24b"
+  integrity sha512-rWwDzm9imWYC+fmc2MhUlw8Uk33vqbncVnesmZKVFtyg5Azm5dJLoua462EAYretYAilmH0u2y/o+XeRAKtGCg==
 
 "@types/estree@0.0.39":
   version "0.0.39"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/nimiq/keyguard-next#readme",
   "devDependencies": {
     "@nimiq/core-web": "1.4.3",
-    "@nimiq/rpc": "^0.0.11",
+    "@nimiq/rpc": "^0.2.1",
     "@nimiq/style": "^0.6.2",
     "@types/jasmine": "^2.8.8",
     "@types/node": "^10.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,10 +113,10 @@
   resolved "https://registry.yarnpkg.com/@nimiq/core-web/-/core-web-1.4.3.tgz#190d7390324623672fafbbc93841bcf215d2af01"
   integrity sha512-47JMAx8bFcr2uev+QgX4saBUvRQo/8akQdpvf0z1F5N3I8FPyIfEWRjPW2Xu28C+MOdIZ/VkHL/YmMiGBBtEMA==
 
-"@nimiq/rpc@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.0.11.tgz#7230365640663827fb115e0d6456222de3b1c5e3"
-  integrity sha512-aSTQwsTeSH46ubRDHqB7x82Alq5a9PlMYJUgDVd/4ET1dMTLm+4sjaFiWho3+SjG2n5/v09XKlDUBFDaENYT6w==
+"@nimiq/rpc@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.2.1.tgz#f39a782eafc7dc8b67e306b85845f114fcd3a24b"
+  integrity sha512-rWwDzm9imWYC+fmc2MhUlw8Uk33vqbncVnesmZKVFtyg5Azm5dJLoua462EAYretYAilmH0u2y/o+XeRAKtGCg==
 
 "@nimiq/style@^0.6.2":
   version "0.6.2"


### PR DESCRIPTION
This adapts the Keyguard's own RpcServer version to the changes in https://github.com/nimiq/rpc/pull/19. The KeyguardClient has already been published as v0.5.1-beta.2.