### PR TITLE
Type updates

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimiq/keyguard-client",
-  "version": "0.5.0-beta.2",
+  "version": "0.5.1",
   "description": "Nimiq Keyguard client library",
   "main": "dist/KeyguardClient.common.js",
   "module": "dist/KeyguardClient.es.js",

--- a/client/src/KeyguardClient.ts
+++ b/client/src/KeyguardClient.ts
@@ -29,6 +29,7 @@ import {
     RedirectResult,
     ExportRequest,
     ObjectType,
+    ResultByCommand,
 } from './PublicRequest';
 
 import Observable from './Observable';
@@ -74,9 +75,9 @@ export class KeyguardClient {
         return this._redirectClient.init();
     }
 
-    public on(
-        command: KeyguardCommand,
-        resolve: (result: RedirectResult, state?: ObjectType|null) => any,
+    public on<T extends KeyguardCommand>(
+        command: T,
+        resolve: (result: ResultByCommand<T>, state?: ObjectType|null) => any,
         reject: (error: Error, state?: ObjectType|null) => any,
     ) {
         this._observable.on(`${command}-resolve`, resolve);

--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -1,4 +1,5 @@
 import * as Nimiq from '@nimiq/core-web';
+import { KeyguardCommand } from './KeyguardCommand';
 
 export type ObjectType = {
     [key: string]: any;
@@ -164,12 +165,21 @@ export type RedirectResult = KeyResult
 
 export type Result = RedirectResult | IFrameResult;
 
+// Derived Result types
+
 export type ResultType<T extends RedirectRequest> =
     T extends Is<T, SignMessageRequest> | Is<T, SignTransactionRequest> ? SignatureResult :
     T extends Is<T, DeriveAddressRequest> ? Is<T, DeriveAddressResult> :
     T extends Is<T, CreateRequest> | Is<T, ImportRequest> ? KeyResult :
     T extends Is<T, ExportRequest> ? ExportResult :
     T extends Is<T, RemoveKeyRequest> | Is<T, SimpleRequest> ? SimpleResult : never;
+
+export type ResultByCommand<T extends KeyguardCommand> =
+    T extends KeyguardCommand.SIGN_MESSAGE | KeyguardCommand.SIGN_TRANSACTION ? SignatureResult :
+    T extends KeyguardCommand.DERIVE_ADDRESS ? DeriveAddressResult :
+    T extends KeyguardCommand.CREATE | KeyguardCommand.IMPORT ? KeyResult :
+    T extends KeyguardCommand.EXPORT ? ExportResult :
+    T extends KeyguardCommand.REMOVE ? SimpleResult : never;
 
 // Error constants
 

--- a/client/src/PublicRequest.ts
+++ b/client/src/PublicRequest.ts
@@ -4,6 +4,9 @@ export type ObjectType = {
     [key: string]: any;
 };
 
+// Returns B if T and B have same keys. Ignores modifiers (readonly, optional)
+export type Is<T, B> = keyof T extends keyof B ? keyof B extends keyof T ? B : never : never;
+
 // Base types for Requests
 export type BasicRequest = {
     appName: string,
@@ -107,8 +110,10 @@ export type SignMessageRequest = SimpleRequest & {
 
 export type RedirectRequest = CreateRequest
     | ImportRequest
+    | ExportRequest
     | SimpleRequest
     | SignTransactionRequest
+    | SignMessageRequest
     | DeriveAddressRequest
     | RemoveKeyRequest;
 
@@ -158,6 +163,13 @@ export type RedirectResult = KeyResult
     | SimpleResult;
 
 export type Result = RedirectResult | IFrameResult;
+
+export type ResultType<T extends RedirectRequest> =
+    T extends Is<T, SignMessageRequest> | Is<T, SignTransactionRequest> ? SignatureResult :
+    T extends Is<T, DeriveAddressRequest> ? Is<T, DeriveAddressResult> :
+    T extends Is<T, CreateRequest> | Is<T, ImportRequest> ? KeyResult :
+    T extends Is<T, ExportRequest> ? ExportResult :
+    T extends Is<T, RemoveKeyRequest> | Is<T, SimpleRequest> ? SimpleResult : never;
 
 // Error constants
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "karma-jasmine": "^1.1.2",
     "nyc": "^12.0.2",
     "tsc-watch": "^1.0.22",
-    "typescript": "^3.3.3"
+    "typescript": "^3.4.5"
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -56,7 +56,7 @@ async function loadNimiq() {
 }
 
 /**
- * @template {KeyguardRequest.RedirectRequest} T 
+ * @template {KeyguardRequest.RedirectRequest} T
  * @param {Newable} RequestApiClass - Class object of the API which is to be exposed via RPC
  * @param {object} [options]
  */

--- a/src/common.js
+++ b/src/common.js
@@ -56,6 +56,7 @@ async function loadNimiq() {
 }
 
 /**
+ * @template {KeyguardRequest.RedirectRequest} T 
  * @param {Newable} RequestApiClass - Class object of the API which is to be exposed via RPC
  * @param {object} [options]
  */
@@ -86,7 +87,7 @@ async function runKeyguard(RequestApiClass, options) { // eslint-disable-line no
     });
 
     // Instantiate handler.
-    /** @type {TopLevelApi | IFrameApi} */
+    /** @type {TopLevelApi<T> | IFrameApi} */
     const api = new RequestApiClass();
 
     /** @type {string} */

--- a/src/lib/RequestParser.js
+++ b/src/lib/RequestParser.js
@@ -217,7 +217,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
     }
 
     /**
-     * @param {any} url
+     * @param {unknown} url
      * @returns {string}
      */
     parseShopOrigin(url) {
@@ -249,7 +249,7 @@ class RequestParser { // eslint-disable-line no-unused-vars
     }
 
     /**
-     * @param {any} value
+     * @param {unknown} value
      * @returns {boolean}
      */
     parseBoolean(value) {

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -37,7 +37,7 @@
  *  runKeyguard(SignTransactionApi);
  * ```
  * @abstract
- * @template {KeyguardRequest.RedirectRequest} T 
+ * @template {KeyguardRequest.RedirectRequest} T
  */
 class TopLevelApi extends RequestParser {
     constructor() {

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -37,6 +37,7 @@
  *  runKeyguard(SignTransactionApi);
  * ```
  * @abstract
+ * @template {KeyguardRequest.RedirectRequest} T 
  */
 class TopLevelApi extends RequestParser {
     constructor() {
@@ -172,10 +173,9 @@ class TopLevelApi extends RequestParser {
 
     /**
      * Overwritten by each request's API class
-     * Note: There is a bug with typescript not parsing 'template {KeyguardRequest.RedirectRequest} T', so we use any.
      *
-     * @param {any} request
-     * @returns {Promise<Parsed<any>>}
+     * @param {unknown} request
+     * @returns {Promise<Parsed<T>>}
      * @abstract
      */
     async parseRequest(request) { // eslint-disable-line no-unused-vars
@@ -190,7 +190,7 @@ class TopLevelApi extends RequestParser {
     /**
      * Can be overwritten by a request's API class to excute code before the handler's run() is called
      * Note: There is a bug with typescript not parsing 'template {KeyguardRequest.RedirectRequest} T', so we use any.
-     * @param {Parsed<any>} parsedRequest
+     * @param {Parsed<T>} parsedRequest
      */
     async onBeforeRun(parsedRequest) { // eslint-disable-line no-unused-vars
         // noop
@@ -199,7 +199,7 @@ class TopLevelApi extends RequestParser {
     /**
      * Called by a page's API class on success
      *
-     * @param {*} result
+     * @param {KeyguardRequest.ResultType<T>} result
      * @returns {Promise<void>}
      */
     async resolve(result) {

--- a/src/request/change-password/ChangePasswordApi.js
+++ b/src/request/change-password/ChangePasswordApi.js
@@ -2,6 +2,7 @@
 /* global ChangePassword */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.SimpleRequest> */
 class ChangePasswordApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.SimpleRequest} request

--- a/src/request/change-password/ChangePasswordApi.js
+++ b/src/request/change-password/ChangePasswordApi.js
@@ -2,7 +2,7 @@
 /* global ChangePassword */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.SimpleRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.SimpleRequest>} */
 class ChangePasswordApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.SimpleRequest} request

--- a/src/request/create/CreateApi.js
+++ b/src/request/create/CreateApi.js
@@ -2,7 +2,7 @@
 /* global Create */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.CreateRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.CreateRequest>} */
 class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.CreateRequest} request

--- a/src/request/create/CreateApi.js
+++ b/src/request/create/CreateApi.js
@@ -2,6 +2,7 @@
 /* global Create */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.CreateRequest> */
 class CreateApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.CreateRequest} request

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -3,7 +3,7 @@
 /* global DeriveAddress */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.DeriveAddressRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.DeriveAddressRequest>} */
 class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.DeriveAddressRequest} request

--- a/src/request/derive-address/DeriveAddressApi.js
+++ b/src/request/derive-address/DeriveAddressApi.js
@@ -3,6 +3,7 @@
 /* global DeriveAddress */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.DeriveAddressRequest> */
 class DeriveAddressApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.DeriveAddressRequest} request

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -2,6 +2,7 @@
 /* global Export */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.ExportRequest> */
 class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.ExportRequest} request

--- a/src/request/export/ExportApi.js
+++ b/src/request/export/ExportApi.js
@@ -2,7 +2,7 @@
 /* global Export */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.ExportRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.ExportRequest>} */
 class ExportApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.ExportRequest} request

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -2,10 +2,11 @@
 /* global ImportFile */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.ImportRequest> */
 class ImportApi extends TopLevelApi {
     /**
      * @param {KeyguardRequest.ImportRequest} request
-     * @returns {Promise<KeyguardRequest.ImportRequest>}
+     * @returns {Promise<Parsed<KeyguardRequest.ImportRequest>>}
      */
     async parseRequest(request) {
         if (!request) {

--- a/src/request/import/ImportApi.js
+++ b/src/request/import/ImportApi.js
@@ -2,7 +2,7 @@
 /* global ImportFile */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.ImportRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.ImportRequest>} */
 class ImportApi extends TopLevelApi {
     /**
      * @param {KeyguardRequest.ImportRequest} request

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -2,7 +2,7 @@
 /* global RemoveKey */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.RemoveKeyRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.RemoveKeyRequest>} */
 class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.RemoveKeyRequest} request

--- a/src/request/remove-key/RemoveKeyApi.js
+++ b/src/request/remove-key/RemoveKeyApi.js
@@ -2,6 +2,7 @@
 /* global RemoveKey */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.RemoveKeyRequest> */
 class RemoveKeyApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.RemoveKeyRequest} request

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -2,6 +2,7 @@
 /* global SignMessage */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.SignMessageRequest> */
 class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.SignMessageRequest} request

--- a/src/request/sign-message/SignMessageApi.js
+++ b/src/request/sign-message/SignMessageApi.js
@@ -2,7 +2,7 @@
 /* global SignMessage */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.SignMessageRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.SignMessageRequest>} */
 class SignMessageApi extends TopLevelApi { // eslint-disable-line no-unused-vars
     /**
      * @param {KeyguardRequest.SignMessageRequest} request

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -3,6 +3,7 @@
 /* global SignTransaction */
 /* global Errors */
 
+/** @extends TopLevelApi<KeyguardRequest.SignTransactionRequest> */
 class SignTransactionApi extends TopLevelApi {
     /**
      * @param {KeyguardRequest.SignTransactionRequest} request

--- a/src/request/sign-transaction/SignTransactionApi.js
+++ b/src/request/sign-transaction/SignTransactionApi.js
@@ -3,7 +3,7 @@
 /* global SignTransaction */
 /* global Errors */
 
-/** @extends TopLevelApi<KeyguardRequest.SignTransactionRequest> */
+/** @extends {TopLevelApi<KeyguardRequest.SignTransactionRequest>} */
 class SignTransactionApi extends TopLevelApi {
     /**
      * @param {KeyguardRequest.SignTransactionRequest} request

--- a/types/Keyguard.d.ts
+++ b/types/Keyguard.d.ts
@@ -43,8 +43,8 @@ type KeyRecord = {
     defaultAddress: Uint8Array
 }
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-type Transform<T, K extends keyof T, E> = Omit<T, K> & E
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+type Transform<T, K extends keyof T, E> = Omit<T, K> & E;
 
 type KeyId2KeyInfo<T extends { keyId: string }> = Transform<T, 'keyId', { keyInfo: KeyInfo }>
 type ConstructTransaction<T extends KeyguardRequest.TransactionInfo> = Transform<T,
@@ -52,17 +52,18 @@ type ConstructTransaction<T extends KeyguardRequest.TransactionInfo> = Transform
     'validityStartHeight' | 'data' | 'flags',
     { transaction: Nimiq.ExtendedTransaction }>
 
+type Is<T, B> = KeyguardRequest.Is<T, B>;
+
 type Parsed<T extends KeyguardRequest.Request> =
-    T extends KeyguardRequest.SignTransactionRequest ? ConstructTransaction<Transform<KeyId2KeyInfo<KeyguardRequest.SignTransactionRequest>,
+    T extends Is<T, KeyguardRequest.SignTransactionRequest>  ? ConstructTransaction<Transform<KeyId2KeyInfo<KeyguardRequest.SignTransactionRequest>,
         'shopLogoUrl', { shopLogoUrl?: URL }>>
         & { layout: KeyguardRequest.SignTransactionRequestLayout } :
-    T extends KeyguardRequest.SignMessageRequest ? Transform<Transform<KeyId2KeyInfo<KeyguardRequest.SignMessageRequest>,
-        'signer', { signer: Nimiq.Address }>,
-        'message', { message: Uint8Array | string }> :
-    T extends KeyguardRequest.SimpleRequest
-        | KeyguardRequest.DeriveAddressRequest
-        | KeyguardRequest.RemoveKeyRequest ? KeyId2KeyInfo<T> :
-    T extends KeyguardRequest.ImportRequest ? Transform<KeyguardRequest.ImportRequest,
+    T extends Is<T, KeyguardRequest.SignMessageRequest> ? Transform<KeyId2KeyInfo<KeyguardRequest.SignMessageRequest>,
+        'signer' | 'message', { signer: Nimiq.Address, message: Uint8Array | string }> :
+    T extends Is<T, KeyguardRequest.SimpleRequest>
+        | Is<T, KeyguardRequest.DeriveAddressRequest>
+        | Is<T, KeyguardRequest.RemoveKeyRequest>
+        | Is<T, KeyguardRequest.ExportRequest> ? KeyId2KeyInfo<T> :
+    T extends Is<T, KeyguardRequest.ImportRequest> ? Transform<KeyguardRequest.ImportRequest,
         'isKeyLost', { isKeyLost: boolean }> :
     T;
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,10 +4454,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.3:
-  version "3.3.3333"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
-  integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
+typescript@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
- Update TypeScript to 3.4.5
- Make ToplevelApi generic, dependent on request type
- Improve precision of Parsed<>
- Derive result type of handlers in client from command