### PR TITLE
Curd/build improvements

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -51,9 +51,16 @@ replace_font_url() {
     sed -i -r -e "s/$OLD_PATH/$NEW_PATH/g" $1
 }
 
+# Replace xxd -r -p with a nice bash function
+function hex_to_binary() {
+    for (( i=0; i<${#1}; i+=2 )); do
+        printf "\x${1:$i:2}"
+    done
+}
+
 # generate a base64 file integrity hash
 make_file_hash() {
-    echo $(${SHA256SUM} "$1" | awk '{print $1}' | xxd -r -p | base64)
+    hex_to_binary "$(${SHA256SUM} "$1" | cut -d' ' -f1)" | base64
 }
 
 # Before writing any files, verify integrity of Nimiq lib

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -9,13 +9,13 @@ output() {
 
 # Check for a working implementation of sha256sum
 SHA256SUM=""
-which sha256sum > /dev/null && SHA256SUM="sha256sum"
+command -v sha256sum > /dev/null && SHA256SUM="sha256sum"
 # For (at least) MacPorts on MacOS, the GNU coreutils have been prefixed with 'g'
 # to be easily seperateable from the BSD ones
-[ -z "${SHA256SUM}" ] && which gsha256sum > /dev/null && SHA256SUM="gsha256sum"
+[ -z "${SHA256SUM}" ] && command -v gsha256sum > /dev/null && SHA256SUM="gsha256sum"
 # Yes, that leaves the possibility that the current version of shasum doesn't
 # support the SHA256 algorithm. But I don't think that's rather common by now...
-[ -z "${SHA256SUM}" ] && which shasum > /dev/null && SHA256SUM="shasum -a 256"
+[ -z "${SHA256SUM}" ] && command -v shasum > /dev/null && SHA256SUM="shasum -a 256"
 
 if [ -z "${SHA256SUM}" ]; then
   output "Please install sha256sum or shasum first."

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -22,6 +22,22 @@ if [ -z "${SHA256SUM}" ]; then
   exit 1
 fi
 
+# Detecting whether we're using GNU or BSD sed. There is a small but significant
+# idiosyncracy regarding the inplace option (-i).
+# Fair warning: Yes, that's quite a hack, but distinguishing GNU and BSD utils
+# isn't that easy.
+if sed --in-place 2>&1 | head -1 | grep -q "illegal"; then
+  # For BSD
+  function inplace_sed() {
+    sed -i "" $@
+  }
+else
+  # For GNU
+  function inplace_sed() {
+    sed -i"" $@
+  }
+fi
+
 # execute config file given as parameter; default to testnet
 BUILD=testnet
 if [ "$1" != "" ]; then
@@ -40,7 +56,7 @@ replace_icon_sprite_url() {
     OLD_PATH="\.\.\/\.\.\/\.\.\/node_modules\/@nimiq\/style\/nimiq-style.icons.svg"
     NEW_PATH="\/assets\/nimiq-style.icons.svg"
 
-    sed -i -e "s/$OLD_PATH/$NEW_PATH/g" $1
+    inplace_sed "s/$OLD_PATH/$NEW_PATH/g" $1
 }
 
 # replace font url in file $1
@@ -48,7 +64,7 @@ replace_font_url() {
     OLD_PATH="(\.\.\/)*assets\/fonts"
     NEW_PATH="\/assets\/fonts"
 
-    sed -i -r -e "s/$OLD_PATH/$NEW_PATH/g" $1
+    inplace_sed -E "s/$OLD_PATH/$NEW_PATH/g" $1
 }
 
 # Replace xxd -r -p with a nice bash function

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -3,6 +3,10 @@
 # Exit on first error
 set -e
 
+# Use default C locale to ensure consistent sorting despite the locale or the
+# operating system.
+export LC_ALL=C
+
 output() {
     echo "$(tput bold) $1$(tput sgr0)"
 }


### PR DESCRIPTION

* Make the build script less dependant on external tools. 
    => Except for git, it now works out of the box on a minimal Fedora.
* Fix build inaccuracy and (potential) errors on MacOS.
    => The build script should be able to detect and avoid differences between GNU and BSD tools to archive platform independence at least to some degree.

The build output before and after the modification remains identical on Fedora (most likely on Linux in general). After the modification, the output is now identical on MacOS too.