### PR TITLE
Refactor cookie writing/deleting to also work during non-HTTPS testing

### DIFF
--- a/demos/Demo.js
+++ b/demos/Demo.js
@@ -48,6 +48,18 @@ class Demo {
         await this._addEntryToDatabase(db, AccountStore.ACCOUNT_DATABASE, deprecatedAccountRecord2);
 
         db.close();
+
+        // Set cookie
+        const cookieAccounts = [{
+            address: deprecatedAccountRecord1.userFriendlyAddress,
+            type: deprecatedAccountRecord1.type,
+            label: deprecatedAccountRecord1.label,
+        }, {
+            address: deprecatedAccountRecord2.userFriendlyAddress,
+            type: deprecatedAccountRecord2.type,
+            label: deprecatedAccountRecord2.label,
+        }];
+        CookieJar.writeCookie('accounts', JSON.stringify(cookieAccounts));
     }
 
     static async _addEntryToDatabase(db, objectStoreName, entry) {

--- a/demos/setup.html
+++ b/demos/setup.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Demo SetUp</title>
     <script src="../node_modules/@nimiq/core-web/web-offline.js"></script>
+    <script src="../src/lib/CookieJar.js"></script>
     <script src="../src/lib/KeyInfo.js"></script>
     <script src="../src/lib/KeyStore.js"></script>
     <script src="../src/lib/AccountStore.js"></script>

--- a/src/lib/CookieJar.js
+++ b/src/lib/CookieJar.js
@@ -5,9 +5,7 @@ class CookieJar { // eslint-disable-line no-unused-vars
      * @param {KeyInfo[]} keys
      */
     static fill(keys) {
-        const maxAge = 60 * 60 * 24 * 365;
-        const encodedKeys = this._encodeCookie(keys);
-        document.cookie = `k=${encodedKeys};max-age=${maxAge.toString()};Secure;SameSite=strict;Path=/`;
+        this.writeCookie('k', this._encodeCookie(keys));
     }
 
     /**
@@ -46,6 +44,23 @@ class CookieJar { // eslint-disable-line no-unused-vars
             );
         }
         return [];
+    }
+
+    /**
+     * @param {string} name
+     * @param {string} value
+     * @param {number} [maxAge]
+     */
+    static writeCookie(name, value, maxAge = 31536000 /* 1 year */) {
+        const secure = window.location.protocol === 'https:' ? 'Secure;' : '';
+        document.cookie = `${name}=${value};max-age=${maxAge.toString()};${secure}SameSite=strict;Path=/`;
+    }
+
+    /**
+     * @param {string} name
+     */
+    static deleteCookie(name) {
+        this.writeCookie(name, '', 0);
     }
 
     /**

--- a/src/lib/KeyStore.js
+++ b/src/lib/KeyStore.js
@@ -4,6 +4,7 @@
 /* global AccountStore */
 /* global BrowserDetection */
 /* global Errors */
+/* global CookieJar */
 
 /**
  * Usage:
@@ -241,10 +242,10 @@ class KeyStore {
 
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
             // Delete migrate cookie
-            document.cookie = 'migrate=0; expires=Thu, 01 Jan 1970 00:00:01 GMT';
+            CookieJar.deleteCookie('migrate');
 
             // Delete accounts cookie
-            document.cookie = 'accounts=; expires=Thu, 01 Jan 1970 00:00:01 GMT';
+            CookieJar.deleteCookie('accounts');
         }
     }
 

--- a/src/request/TopLevelApi.js
+++ b/src/request/TopLevelApi.js
@@ -68,7 +68,7 @@ class TopLevelApi extends RequestParser {
          *
          * @deprecated Only for database migration
          */
-        if ((BrowserDetection.isIOS() || BrowserDetection.isSafari())) {
+        if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
             if (TopLevelApi._hasMigrateFlag()) {
                 await KeyStore.instance.migrateAccountsToKeys();
             }
@@ -92,7 +92,7 @@ class TopLevelApi extends RequestParser {
                     }
                 }
                 // crumble
-                document.cookie = 'removeKey=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                CookieJar.deleteCookie('removeKey');
             }
         }
 

--- a/src/request/iframe/IFrameApi.js
+++ b/src/request/iframe/IFrameApi.js
@@ -61,8 +61,7 @@ class IFrameApi {
                     removeKeyArray = [];
                 }
                 removeKeyArray.push(request.keyId);
-                document.cookie = `removeKey=${JSON.stringify(removeKeyArray)};max-age=31536000;`
-                                + 'Secure;SameSite=strict;Path=/';
+                CookieJar.writeCookie('removeKey', JSON.stringify(removeKeyArray));
             } else {
                 await KeyStore.instance.remove(request.keyId);
             }
@@ -110,7 +109,7 @@ class IFrameApi {
          */
         if (BrowserDetection.isIOS() || BrowserDetection.isSafari()) {
             // Set migrate flag cookie
-            document.cookie = 'migrate=1;max-age=31536000;Secure;SameSite=strict;Path=/';
+            CookieJar.writeCookie('migrate', '1');
             return { success: true };
         }
 

--- a/tests/lib/KeyStore.spec.js
+++ b/tests/lib/KeyStore.spec.js
@@ -157,7 +157,7 @@ describe('KeyStore', () => {
                 accountsCookieDeleted = true;
             }
             expect(migrationCookieDeleted || accountsCookieDeleted).toBe(true);
-            expect(cookie.includes('expires=Thu, 01 Jan 1970 00:00:01 GMT')).toBe(true);
+            expect(cookie.includes('max-age=0')).toBe(true);
         });
 
         await KeyStore.instance.migrateAccountsToKeys();


### PR DESCRIPTION
Also writes a cookie when setting up legacy accounts during testing, to test migration on iOS/Safari.

Because it did not work initially, I found out that the current cookie logic always sets the `Secure;` property, which does not work on non-HTTPS localhost.