### PR TITLE
Small style updates

### DIFF
--- a/src/components/AddressInfoDetailed.css
+++ b/src/components/AddressInfoDetailed.css
@@ -10,8 +10,9 @@
 .address-info.detailed-view .label {
     font-size: 3rem;
     font-weight: 600;
-    line-height: 1;
+    line-height: 1.3;
     margin-top: 3rem;
+    text-align: center;
 }
 
 .address-info.detailed-view .account-label {

--- a/src/components/ValidateWords.css
+++ b/src/components/ValidateWords.css
@@ -48,6 +48,7 @@
 .validate-words button[disabled].green {
     /* @nimiq/style does not include disabled styles for colored buttons yet */
     background: var(--nimiq-green-bg) !important;
+    color: white;
     opacity: 1;
     cursor: pointer;
 }
@@ -55,12 +56,14 @@
 .validate-words button[disabled].red {
     /* @nimiq/style does not include disabled styles for colored buttons yet */
     background: var(--nimiq-red-bg) !important;
+    color: white;
     opacity: 1;
     cursor: pointer;
 }
 
 .validate-words button.blink-green {
     opacity: 1;
+    color: white;
     animation-name: blink-green;
     animation-duration: 400ms;
     animation-iteration-count: 2;

--- a/src/components/ValidateWords.js
+++ b/src/components/ValidateWords.js
@@ -183,15 +183,18 @@ class ValidateWords extends Nimiq.Observable {
      * @private
      */
     _onButtonPressed($button) {
+        const correctButtonIndex = this._wordList.indexOf(this._targetWord);
+
         this.$buttons.forEach(button => {
             button.disabled = true;
-            button.classList.add('inverse');
+            if (button !== $button && button !== this.$buttons[correctButtonIndex]) {
+                button.classList.add('inverse');
+            }
         });
 
         if ($button.textContent !== this._targetWord) {
             // wrong choice
             ValidateWords._showAsWrong($button);
-            const correctButtonIndex = this._wordList.indexOf(this._targetWord);
             ValidateWords._showAsCorrect(this.$buttons[correctButtonIndex], false);
             setTimeout(() => this.reset(), 820);
         } else {

--- a/src/request/export/Export.css
+++ b/src/request/export/Export.css
@@ -163,7 +163,8 @@ ul.nq-list li > .nq-icon {
 }
 
 .page#recovery-words .recovery-words {
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: hidden;
 }
 
 .page#login-file-download:target img,
@@ -178,7 +179,8 @@ ul.nq-list li > .nq-icon {
 }
 
 .page#recovery-words:target .recovery-words {
-    overflow: hidden scroll;
+    overflow-y: scroll;
+    overflow-x: hidden;
 }
 
 .page#login-file-unlock:target ~ .page#login-file-download,

--- a/src/request/export/Export.css
+++ b/src/request/export/Export.css
@@ -239,6 +239,19 @@ ul.nq-list li > .nq-icon {
     position: relative;
 }
 
+.page#login-file-success .page-header-back-button {
+    left: auto;
+    right: 2rem;
+    top: 2rem;
+    opacity: 0.16;
+    transition: opacity .3s ease;
+}
+
+.page#login-file-success .page-header-back-button:hover {
+    transform: none;
+    opacity: 0.25;
+}
+
 .page#login-file-success .bullet-point::before {
     content: '\25cf';
     position: absolute;

--- a/src/request/export/Export.css
+++ b/src/request/export/Export.css
@@ -143,7 +143,7 @@ ul.nq-list li > .nq-icon {
 .page#login-file-download img {
     display: flex;
     transition: filter .6s, opacity .6s;
-    opacity: .3;
+    opacity: .15;
     -webkit-filter: blur(20px);
     -moz-filter: blur(20px);
     -o-filter: blur(20px);
@@ -211,6 +211,15 @@ ul.nq-list li > .nq-icon {
 .page#recovery-words-unlock {
     background-image: none;
     background-color: rgb( 255, 255, 255, .0); /* transparent white */
+}
+
+.page#login-file-success {
+    opacity: 0;
+    transition: opacity .3s .1s ease;
+}
+
+.page#login-file-success:target {
+    opacity: 1;
 }
 
 .page#login-file-success .page-body {

--- a/src/request/export/Export.css
+++ b/src/request/export/Export.css
@@ -252,13 +252,26 @@ ul.nq-list li > .nq-icon {
     left: auto;
     right: 2rem;
     top: 2rem;
-    opacity: 0.16;
-    transition: opacity .3s ease;
+    height: 3rem;
+    padding: 0;
+    opacity: 1;
 }
 
-.page#login-file-success .page-header-back-button:hover {
+.page#login-file-success .page-header-back-button .nq-icon {
+    opacity: .2;
+    transition: opacity .3s cubic-bezier(0.25, 0, 0, 1);
+}
+
+.page#login-file-success .page-header-back-button:hover,
+.page#login-file-success .page-header-back-button:active,
+.page#login-file-success .page-header-back-button:focus {
     transform: none;
-    opacity: 0.25;
+}
+
+.page#login-file-success .page-header-back-button:hover .nq-icon,
+.page#login-file-success .page-header-back-button:active .nq-icon,
+.page#login-file-success .page-header-back-button:focus .nq-icon {
+    opacity: .4;
 }
 
 .page#login-file-success .bullet-point::before {

--- a/src/request/export/Export.js
+++ b/src/request/export/Export.js
@@ -86,8 +86,7 @@ class Export {
             this._resolve(this.exported);
         } else {
             this._fileSuccessPage.classList.add('display-flex');
-            // eslint-disable-next-line no-unused-expressions
-            this._fileSuccessPage.offsetHeight;
+            this._fileSuccessPage.offsetHeight; // eslint-disable-line no-unused-expressions
             window.location.hash = Export.Pages.LOGIN_FILE_SUCCESS;
             window.requestAnimationFrame(() => this._fileSuccessPage.classList.remove('display-flex'));
         }

--- a/src/request/export/Export.js
+++ b/src/request/export/Export.js
@@ -85,7 +85,11 @@ class Export {
         if (this._request.fileOnly) {
             this._resolve(this.exported);
         } else {
+            this._fileSuccessPage.classList.add('display-flex');
+            // eslint-disable-next-line no-unused-expressions
+            this._fileSuccessPage.offsetHeight;
             window.location.hash = Export.Pages.LOGIN_FILE_SUCCESS;
+            window.requestAnimationFrame(() => this._fileSuccessPage.classList.remove('display-flex'));
         }
     }
 

--- a/src/request/export/index.html
+++ b/src/request/export/index.html
@@ -274,7 +274,7 @@
 
             <div id="login-file-success" class="page nq-card">
                 <div class="page-body nq-card-body">
-                    <a tabindex="0" class="page-header-back-button">
+                    <a tabindex="0" class="page-header-back-button nq-button-s">
                         <svg class="nq-icon"><use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-close"/></svg>
                     </a>
                     <ul>

--- a/src/request/sign-transaction/SignTransaction.css
+++ b/src/request/sign-transaction/SignTransaction.css
@@ -96,32 +96,26 @@
     position: absolute;
     right: 2rem;
     top: 2rem;
-    opacity: 0.16;
     border: 0rem;
-    background: transparent;
     padding: 0;
-    transition: opacity .3s ease;
-}
-
-#confirm-transaction #account-details #close-details svg {
-    width: 3rem;
     height: 3rem;
 }
 
-#confirm-transaction #account-details #close-details::after {
-    content: '';
-    position: absolute;
-    left: -1.5rem;
-    right: -1.5rem;
-    top: -1.5rem;
-    bottom: -1.5rem;
+#confirm-transaction #account-details #close-details {
     cursor: pointer;
 }
 
-#confirm-transaction #account-details #close-details:hover,
-#confirm-transaction #account-details #close-details:focus {
-    opacity: 0.25;
-    outline: none;
+#confirm-transaction #account-details #close-details .nq-icon {
+    height: 3rem;
+    width: 3rem;
+    opacity: .2;
+    transition: opacity .3s cubic-bezier(0.25, 0, 0, 1);
+}
+
+#confirm-transaction #account-details #close-details:hover .nq-icon,
+#confirm-transaction #account-details #close-details:active .nq-icon,
+#confirm-transaction #account-details #close-details:focus .nq-icon {
+    opacity: .4;
 }
 
 #confirm-transaction .accounts {

--- a/src/request/sign-transaction/index.html
+++ b/src/request/sign-transaction/index.html
@@ -69,7 +69,7 @@
     <div id="app">
         <div id="confirm-transaction" class="page nq-card">
             <div id="account-details">
-                <button id="close-details">
+                <button id="close-details" class="nq-button-s">
                     <svg class="nq-icon"><use xlink:href="../../../node_modules/@nimiq/style/nimiq-style.icons.svg#nq-close"/></svg>
                 </button>
                 <div id="details"></div>


### PR DESCRIPTION
According to @julianbauer's feedback:
 - Updates the login-file success transition. The text does now fade in with a short delay and does no longer appear instantaneous.
 - File export success screen close icon now has the correct styling.
 - Centers the label in the AddressInfo overlay.
 - Reduces the opacity of the blurred Login File.
 - fixes a bug that made the recovery words not scrollable on safari
 - fixes the display of the different states in validate words

Resolves #346.