### PR TITLE
Reset old testnet database (upgrading to database version 4)

### DIFF
--- a/src/lib/KeyStore.js
+++ b/src/lib/KeyStore.js
@@ -52,29 +52,11 @@ class KeyStore {
                 /** @type {IDBDatabase} */
                 const db = request.result;
 
-                if (event.oldVersion < 1) {
-                    // Version 1 is the first version of the database.
-                    db.createObjectStore(KeyStore.DB_KEY_STORE_NAME, { keyPath: 'id' });
-                }
-
-                if (event.oldVersion < 2) {
-                    // Version 2 changes the key id calculation, thus we drop and recreate the whole database.
-                    // (Version 1 was only in use in testnet)
-                    db.deleteObjectStore(KeyStore.DB_KEY_STORE_NAME);
-                    db.createObjectStore(KeyStore.DB_KEY_STORE_NAME, { keyPath: 'id', autoIncrement: true });
-                }
-
-                if (event.oldVersion < 3) {
-                    // Version 3 changes the key id calculation, thus we drop and recreate the whole database.
-                    // (Version 2 was only in use in testnet)
-                    db.deleteObjectStore(KeyStore.DB_KEY_STORE_NAME);
-                    db.createObjectStore(KeyStore.DB_KEY_STORE_NAME, { keyPath: 'id' });
-                }
-
                 if (event.oldVersion < 4) {
-                    // Change to version 4 just to delete former testnet databases, because we do the same in hub.
-                    // (Version 3 was only in use in testnet)
-                    db.deleteObjectStore(KeyStore.DB_KEY_STORE_NAME);
+                    // Setup the database, deleting old testnet versions (prior to 4) if existing.
+                    try {
+                        db.deleteObjectStore(KeyStore.DB_KEY_STORE_NAME);
+                    } catch (e) {} // eslint-disable-line no-empty
                     db.createObjectStore(KeyStore.DB_KEY_STORE_NAME, { keyPath: 'id' });
                 }
             };

--- a/src/lib/KeyStore.js
+++ b/src/lib/KeyStore.js
@@ -70,6 +70,13 @@ class KeyStore {
                     db.deleteObjectStore(KeyStore.DB_KEY_STORE_NAME);
                     db.createObjectStore(KeyStore.DB_KEY_STORE_NAME, { keyPath: 'id' });
                 }
+
+                if (event.oldVersion < 4) {
+                    // Change to version 4 just to delete former testnet databases, because we do the same in hub.
+                    // (Version 3 was only in use in testnet)
+                    db.deleteObjectStore(KeyStore.DB_KEY_STORE_NAME);
+                    db.createObjectStore(KeyStore.DB_KEY_STORE_NAME, { keyPath: 'id' });
+                }
             };
         });
 
@@ -360,7 +367,7 @@ class KeyStore {
 /** @type {KeyStore?} */
 KeyStore._instance = null;
 
-KeyStore.DB_VERSION = 3;
+KeyStore.DB_VERSION = 4;
 KeyStore.DB_NAME = 'nimiq-keyguard';
 KeyStore.DB_KEY_STORE_NAME = 'keys';
 


### PR DESCRIPTION
The database in the hub is reset as the wallet ids changed by salting them.
Therefore resetting the keyguard database here too, to match the hub database.

Before the release, we could consider though to rename the database, to avoid the need to go through all the versions. Or alternatively to not destroy and recreate them several times but just check for `event.oldVersion < 4`